### PR TITLE
Failing test for <StrictMode>

### DIFF
--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1218,14 +1218,13 @@ describe('React', () => {
       const store = createStore(() => ({}))
 
       function makeContainer(mapState, mapDispatch, mergeProps) {
-        return React.createElement(
-          @connect(mapState, mapDispatch, mergeProps)
-          class Container extends Component {
-            render() {
-              return <Passthrough />
-            }
+        @connect(mapState, mapDispatch, mergeProps)
+        class Container extends Component {
+          render() {
+            return <Passthrough />
           }
-        )
+        }
+        return React.createElement(Container)
       }
 
       function AwesomeMap() { }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2323,5 +2323,27 @@ describe('React', () => {
       expect(mapStateToPropsC).toHaveBeenCalledTimes(2)
       expect(mapStateToPropsD).toHaveBeenCalledTimes(2)
     })
+
+    it('works in <StrictMode> without warnings', () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const store = createStore(stringBuilder)
+
+      @connect(state => ({ string: state }) )
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props}/>
+        }
+      }
+
+      TestRenderer.create(
+        <React.StrictMode>
+          <ProviderMock store={store}>
+            <Container />
+          </ProviderMock>
+        </React.StrictMode>
+      )
+
+      expect(spy).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
Doesn't fix #897. But lets us know what's going to break in future versions of React:
```
Warning: Unsafe lifecycle methods were found within a strict-mode tree:

    componentWillReceiveProps: Please update the following components to use static getDerivedStateFromProps instead: Connect(Container)

    componentWillUpdate: Please update the following components to use componentDidUpdate instead: Connect(Container)

    Learn more about this warning here:
    https://fb.me/react-strict-mode-warnings
```
If others want to fix this, you can use this branch as a base. Feel free to try it out!
