### PR TITLE
Remove subkey

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -19,8 +19,8 @@ function warnAboutReceivingStore() {
   )
 }
 
-export function createProvider(storeKey = 'store', subKey) {
-    const subscriptionKey = subKey || `${storeKey}Subscription`
+export function createProvider(storeKey = 'store') {
+    const subscriptionKey = `${storeKey}Subscription`
 
     class Provider extends Component {
         getChildContext() {

--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -1,5 +1,5 @@
 import verifySubselectors from './verifySubselectors'
-  
+
 export function impureFinalPropsSelectorFactory(
   mapStateToProps,
   mapDispatchToProps,
@@ -64,7 +64,7 @@ export function pureFinalPropsSelectorFactory(
     const nextStateProps = mapStateToProps(state, ownProps)
     const statePropsChanged = !areStatePropsEqual(nextStateProps, stateProps)
     stateProps = nextStateProps
-    
+
     if (statePropsChanged)
       mergedProps = mergeProps(stateProps, dispatchProps, ownProps)
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import TestRenderer from 'react-test-renderer'
 import { createStore } from 'redux'
-import { connect } from '../../src/index'
+import { connect, createProvider } from '../../src/index'
 
 describe('React', () => {
   describe('connect', () => {
@@ -2323,6 +2323,28 @@ describe('React', () => {
       expect(mapStateToPropsB).toHaveBeenCalledTimes(2)
       expect(mapStateToPropsC).toHaveBeenCalledTimes(2)
       expect(mapStateToPropsD).toHaveBeenCalledTimes(2)
+    })
+
+    it('should receive the store in the context using a custom store key', () => {
+      const store = createStore(() => ({}))
+      const CustomProvider = createProvider('customStoreKey')
+      const connectOptions = { storeKey: 'customStoreKey' }
+
+      @connect(undefined, undefined, undefined, connectOptions)
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const testRenderer = TestRenderer.create(
+        <CustomProvider store={store}>
+          <Container />
+        </CustomProvider>
+      )
+
+      const container = testRenderer.root.findByType(Container)
+      expect(container.instance.store).toBe(store)
     })
   })
 })


### PR DESCRIPTION
This pr removed `subKey` option from `createProvider`.

The `subKey` isn't really useful because `connect` components doesn't know the custom subscription key.
And according to discussion #944 , removing the `subKey` makes things simpler.

- Remove subkey
- Add tests to `Provider`