### PR TITLE
update validation of component passed to the function returned by connect()

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "invariant": "^2.2.4",
     "loose-envify": "^1.1.0",
     "prop-types": "^15.6.1",
+    "react-is": "^16.4.1",
     "react-lifecycles-compat": "^3.0.0"
   },
   "devDependencies": {

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -1,6 +1,7 @@
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
 import { Component, createElement } from 'react'
+import * as ReactIs from 'react-is'
 
 import Subscription from '../utils/Subscription'
 import { storeShape, subscriptionShape } from '../utils/PropTypes'
@@ -88,7 +89,7 @@ export default function connectAdvanced(
 
   return function wrapWithConnect(WrappedComponent) {
     invariant(
-      typeof WrappedComponent == 'function',
+      ReactIs.isValidElementType(WrappedComponent),
       `You must pass a component to the function returned by ` +
       `${methodName}. Instead received ${JSON.stringify(WrappedComponent)}`
     )

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1206,6 +1206,16 @@ describe('React', () => {
       )
     })
 
+    it('should not throw an error if a object created with React.forwardRef is passed to the function returned by connect', () => {
+      const ForwardRefComponent = React.forwardRef((props, ref) =>
+        <div {...props} ref={ref} />
+      );
+
+      expect(() => {
+        connect()(ForwardRefComponent)
+      }).not.toThrow()
+    });
+
     it('should throw an error if mapState, mapDispatch, or mergeProps returns anything but a plain object', () => {
       const store = createStore(() => ({}))
 
@@ -1544,7 +1554,7 @@ describe('React', () => {
 
     it('should throw an error if the store is not in the props or context', () => {
       const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
-      
+
       class Container extends Component {
         render() {
           return <Passthrough />


### PR DESCRIPTION
Fixes #914 

This aims to remove the strict function check and use react-is to validate the component that is passed to the function returned by connect(). I first encountered this issue when I created an HOC that forwarded a reference to the composed component, as discussed in the issue referenced above.
