### PR TITLE
API Doc code excerpt: log message hint fix for ownProps on map function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -102,9 +102,10 @@ function mapStateToProps(state) {
 ```js
 const mapStateToProps = (state, ownProps = {}) => {
   console.log(state); // state
-  console.log(ownProps); // undefined
+  console.log(ownProps); // {}
 }
 ```
+
 Functions with no mandatory parameters or two parameters **will receive** `ownProps`.
 ```js
 const mapStateToProps = (state, ownProps) => {


### PR DESCRIPTION
- mapStateToProps with default value for `ownProps` parameter
- hence `ownProps` always be the default value

Related issue #1055 