### PR TITLE
Add nodejs version 10 for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "8"
+  - "10"
 before_install:
   - 'nvm install-latest-npm'
 env:


### PR DESCRIPTION
**Summary**

This PR adds nodejs version `10` for the Travis Ci build

Details: 
* https://github.com/nodejs/Release#end-of-life-releases
* https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

![image](https://user-images.githubusercontent.com/25740248/47252831-f1f67580-d485-11e8-8ae0-1525cfd154df.png)