### PR TITLE
remove react-is/isValidElementType from production builds

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -88,11 +88,13 @@ export default function connectAdvanced(
   }
 
   return function wrapWithConnect(WrappedComponent) {
-    invariant(
-      isValidElementType(WrappedComponent),
-      `You must pass a component to the function returned by ` +
-      `${methodName}. Instead received ${JSON.stringify(WrappedComponent)}`
-    )
+    if (process.env.NODE_ENV !== 'production') {
+      invariant(
+        isValidElementType(WrappedComponent),
+        `You must pass a component to the function returned by ` +
+        `${methodName}. Instead received ${JSON.stringify(WrappedComponent)}`
+      );
+    }
 
     const wrappedComponentName = WrappedComponent.displayName
       || WrappedComponent.name


### PR DESCRIPTION
This is a proposal to only run the code for checking whether an element is valid in non-production builds. 

By implementing this change, bundlers can tree shake out `react-is` altogether for production builds 👍 

I think this is fine to be a development only check