### PR TITLE
Add reference to why-did-you-update-redux

### DIFF
--- a/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
+++ b/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
@@ -150,7 +150,9 @@ Many common operations result in new object or array references being created:
 - Copying values with `Object.assign`
 - Copying values with the spread operator `{ ...oldState, ...newData }`
 
-Put these operations in [memoized selector functions]() to ensure that they only run if the input values have changed.  This will also ensure that if the input values _haven't_ changed, `mapStateToProps` will still return the same result values as before, and `connect` can skip re-rendering.
+Put these operations in memoized selector functions like [reselect](https://github.com/reduxjs/reselect) to ensure that they only run if the input values have changed.  This will also ensure that if the input values _haven't_ changed, `mapStateToProps` will still return the same result values as before, and `connect` can skip re-rendering.
+
+If you are not sure what should be memoized, or want to test quality of your memoization, you may use [why-did-you-update-redux](https://github.com/theKashey/why-did-you-update-redux). If you dont like selectors or memoization at all - feel free to use [automatic memoization](https://github.com/theKashey/beautiful-react-redux).
 
 
 


### PR DESCRIPTION
- Adding hint about using __why-did-you-update-redux__ as a mapStateToProps/selector quality accession.
- Adding a reference to __beautiful-react-redux__ as a way of automated selector memoization.

As a reference -  beautiful-react-redux is based on `memoize-state` which is based on automated state key usage tracking, and able to provide a proper memoization almost for any selector. If it did memoization job better than user - then it could guide user to a better memoization. This feature comes with a cost, but it's much lower that a cost of react component update.