### PR TITLE
Treat `null` as a valid plain object prototype in `isPlainObject()`

### DIFF
--- a/src/utils/isPlainObject.js
+++ b/src/utils/isPlainObject.js
@@ -5,10 +5,13 @@
 export default function isPlainObject(obj) {
   if (typeof obj !== 'object' || obj === null) return false
 
-  let proto = obj
-  while (Object.getPrototypeOf(proto) !== null) {
-    proto = Object.getPrototypeOf(proto)
+  let proto = Object.getPrototypeOf(obj)
+  if (proto === null) return true
+
+  let baseProto = proto
+  while (Object.getPrototypeOf(baseProto) !== null) {
+    baseProto = Object.getPrototypeOf(baseProto)
   }
 
-  return Object.getPrototypeOf(obj) === proto
+  return proto === baseProto
 }

--- a/test/utils/isPlainObject.spec.js
+++ b/test/utils/isPlainObject.spec.js
@@ -17,5 +17,6 @@ describe('isPlainObject', () => {
     expect(isPlainObject(null)).toBe(false)
     expect(isPlainObject()).toBe(false)
     expect(isPlainObject({ x: 1, y: 2 })).toBe(true)
+    expect(isPlainObject(Object.create(null))).toBe(true)
   })
 })


### PR DESCRIPTION
Fixes #1074