### PR TITLE
propsAndStateChanged avoid call mapStateToProps and mapDispatchToProp repeatly

### DIFF
--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -74,12 +74,13 @@ export function pureFinalPropsSelectorFactory(
   function handleSubsequentCalls(nextState, nextOwnProps) {
     const propsChanged = !areOwnPropsEqual(nextOwnProps, ownProps)
     const stateChanged = !areStatesEqual(nextState, state)
+    const propsAndStateChanged = propsChanged && stateChanged
     state = nextState
     ownProps = nextOwnProps
 
-    if (propsChanged && stateChanged) return handleNewPropsAndNewState()
-    if (propsChanged) return handleNewProps()
-    if (stateChanged) return handleNewState()
+    if (propsAndStateChanged) return handleNewPropsAndNewState()
+    if (!propsAndStateChanged && propsChanged) return handleNewProps()
+    if (!propsAndStateChanged && stateChanged) return handleNewState()
     return mergedProps
   }
 


### PR DESCRIPTION
First time to PR
In previous code
```
if (propsChanged && stateChanged) return handleNewPropsAndNewState()
if (propsChanged) return handleNewProps()
if (stateChanged) return handleNewState()
```
I think when props and state all changed, `handleNewPropsAndNewState()` has already called `mapStateToProps` and `mapDispatchToProps`, so call `handleNewProps()` or `handleNewState()` makes no sense.
How about use `propsAndStateChanged` to store props and state changed or not, to avoid call `handleNewProps()` and `handleNewState()` repeatly.
```
const propsAndStateChanged = propsChanged && stateChanged
if (propsAndStateChanged) return handleNewPropsAndNewState()
if (!propsAndStateChanged && propsChanged) return handleNewProps()
if (!propsAndStateChanged && stateChanged) return handleNewState()
```