### PR TITLE
Add a LegacyProvider component

### DIFF
--- a/src/components/LegacyProvider.js
+++ b/src/components/LegacyProvider.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import Provider from './Provider'
+
+class LegacyProvider extends Component {
+  getChildContext() {
+    return { store: this.props.store }
+  }
+
+  render() {
+    const { store, ...props } = this.props
+    return <Provider store={store} {...props} />
+  }
+}
+
+LegacyProvider.propTypes = {
+  store: PropTypes.shape({
+    subscribe: PropTypes.func.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    getState: PropTypes.func.isRequired
+  })
+}
+
+LegacyProvider.childContextTypes = {
+  store: PropTypes.object.isRequired
+}
+
+export default LegacyProvider

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import Provider from './components/Provider'
+import LegacyProvider from './components/LegacyProvider'
 import connectAdvanced from './components/connectAdvanced'
 import { ReactReduxContext } from './components/Context'
 import connect from './connect/connect'
 
-export { Provider, connectAdvanced, ReactReduxContext, connect }
+export { Provider, LegacyProvider, connectAdvanced, ReactReduxContext, connect }

--- a/test/components/LegacyProvider.spec.js
+++ b/test/components/LegacyProvider.spec.js
@@ -1,0 +1,43 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { LegacyProvider } from '../../src/index.js'
+import { createStore } from 'redux'
+import * as rtl from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+const createExampleTextReducer = () => (state = 'example text') => state
+
+describe('LegacyProvider', () => {
+  it('provides a legacy context', () => {
+    class LegacyChild extends Component {
+      render() {
+        const store = this.context.store
+
+        let text = ''
+
+        if (store) {
+          text = store.getState().toString()
+        }
+
+        return <div data-testid="store">{text}</div>
+      }
+    }
+
+    LegacyChild.contextTypes = {
+      store: PropTypes.object.isRequired
+    }
+
+    const store = createStore(createExampleTextReducer())
+
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const tester = rtl.render(
+      <LegacyProvider store={store}>
+        <LegacyChild />
+      </LegacyProvider>
+    )
+    expect(spy).toHaveBeenCalledTimes(0)
+    spy.mockRestore()
+
+    expect(tester.getByTestId('store')).toHaveTextContent('example text')
+  })
+})

--- a/test/components/LegacyProvider.spec.js
+++ b/test/components/LegacyProvider.spec.js
@@ -1,13 +1,17 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { LegacyProvider } from '../../src/index.js'
-import { createStore } from 'redux'
 import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'
+
+import { createStore } from 'redux'
+import { LegacyProvider } from '../../src/index.js'
+import { ReactReduxContext } from '../../src/components/Context'
 
 const createExampleTextReducer = () => (state = 'example text') => state
 
 describe('LegacyProvider', () => {
+  afterEach(() => rtl.cleanup())
+
   it('provides a legacy context', () => {
     class LegacyChild extends Component {
       render() {
@@ -33,6 +37,33 @@ describe('LegacyProvider', () => {
     const tester = rtl.render(
       <LegacyProvider store={store}>
         <LegacyChild />
+      </LegacyProvider>
+    )
+    expect(spy).toHaveBeenCalledTimes(0)
+    spy.mockRestore()
+
+    expect(tester.getByTestId('store')).toHaveTextContent('example text')
+  })
+
+  it('passes through everything to the new Provider and provides the new Context as well', () => {
+    class Child extends Component {
+      render() {
+        return (
+          <ReactReduxContext.Consumer>
+            {({ storeState }) => {
+              return <div data-testid="store">{storeState}</div>
+            }}
+          </ReactReduxContext.Consumer>
+        )
+      }
+    }
+
+    const store = createStore(createExampleTextReducer())
+
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const tester = rtl.render(
+      <LegacyProvider store={store}>
+        <Child />
       </LegacyProvider>
     )
     expect(spy).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
This avoids polluting Provider with StrictMode-incompatible stuff. Hopefully, this makes working with outdated libraries easier.

This is per [Dan's comment](https://github.com/reduxjs/react-redux/issues/1083#issuecomment-439923981)