### PR TITLE
Minor optimization: remove conditional

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -151,12 +151,6 @@ export default function connectAdvanced(
 
         const nextProps = sourceSelector(state, props)
 
-        // Conditional test costs more than just assigning each time
-        // See: https://jsperf.com/conditional-vs-not
-        // if (lastDerivedProps === nextProps) {
-        //   return lastDerivedProps
-        // }
-
         lastDerivedProps = nextProps
         return lastDerivedProps
       }

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -151,9 +151,11 @@ export default function connectAdvanced(
 
         const nextProps = sourceSelector(state, props)
 
-        if (lastDerivedProps === nextProps) {
-          return lastDerivedProps
-        }
+        // Conditional test costs more than just assigning each time
+        // See: https://jsperf.com/conditional-vs-not
+        // if (lastDerivedProps === nextProps) {
+        //   return lastDerivedProps
+        // }
 
         lastDerivedProps = nextProps
         return lastDerivedProps


### PR DESCRIPTION
The conditional in selectDerivedProps is unnecessary. The code behaves
identically now but saves about 10% of performance for that portion of
the function.

See: https://jsperf.com/conditional-vs-not

Code left in place but commented in case someone ever wants to add
something like it back for "clarity".