### PR TITLE
docs/using-react-redux: Fixes typo

### DIFF
--- a/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
+++ b/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
@@ -374,7 +374,7 @@ There are discussions regarding whether to provide `dispatch` to your components
 
 ### Can I `mapDispatchToProps` without `mapStateToProps` in Redux?
 
-Yes. You can skip the first parameter by passing `undefined` or `null`. Your component will not subscribe to the store, and will still receive the dispatch props defined by `mapStateToProps`.
+Yes. You can skip the first parameter by passing `undefined` or `null`. Your component will not subscribe to the store, and will still receive the dispatch props defined by `mapDispatchToProps`.
 
 ```js
 connect(


### PR DESCRIPTION
My first read of the docs as currently written is that they incorrectly use the term `mapStateToProps` instead of `mapDispatchToProps` in the answer to "Can I mapDispatchToProps without mapStateToProps in Redux?" This version fixes that, assuming my reading is correct.