### PR TITLE
Update react-router usage example

### DIFF
--- a/docs/api/Provider.md
+++ b/docs/api/Provider.md
@@ -88,10 +88,9 @@ const store = createStore()
 ReactDOM.render(
   <Provider store={store}>
     <Router history={history}>
-      <Route path="/" component={App}>
-        <Route path="foo" component={Foo} />
-        <Route path="bar" component={Bar} />
-      </Route>
+      <Route exact path="/" component={App} />
+      <Route path="/foo" component={Foo} />
+      <Route path="/bar" component={Bar} />
     </Router>
   </Provider>,
   document.getElementById('root')


### PR DESCRIPTION
The example is incorrect - you can't mix `children` and `component` prop. Looks like some left-over from v3 API?