### PR TITLE
Update Provider.md and quick-start.md

### DIFF
--- a/docs/api/Provider.md
+++ b/docs/api/Provider.md
@@ -5,7 +5,7 @@ sidebar_label: Provider
 hide_title: true
 ---
 
-# `<Provider />`
+# `Provider`
 
 ## Overview
 

--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -27,7 +27,7 @@ yarn add react-redux
 
 You'll also need to [install Redux](https://redux-docs.netlify.com/introduction/installation) and [set up a Redux store](https://redux-docs.netlify.com/recipes/configuring-your-store) in your app.
 
-## `<Provider />`
+## `Provider`
 
 React Redux provides `<Provider />`, which makes the Redux store available to the rest of your app:
 


### PR DESCRIPTION
This PR fixes a typo.

The Docusaurus can't convert `<Provider />` to a navigator item in the page nav.

<img width="191" alt="image" src="https://user-images.githubusercontent.com/8492441/52544337-43d35a80-2deb-11e9-8d56-a50b0f86964a.png">

The modification of the Provider.md is to maintain consistency.