### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -16,7 +16,7 @@ React Redux 6.x requires **React 16.4 or later.**
 To use React Redux with your React app:
 
 ```bash
-npm install --save react-redux
+npm install react-redux
 ```
 
 or


### PR DESCRIPTION
Just like https://github.com/reduxjs/redux/pull/3357

"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358