### PR TITLE
6.x - Refactor to fix performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
+.idea/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^16.4.0-0",
+    "react": "^16.6.0-0",
+    "react-dom": "^16.6.0-0",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,13 +9,14 @@ const env = process.env.NODE_ENV
 
 const config = {
   input: 'src/index.js',
-  external: Object.keys(pkg.peerDependencies || {}),
+  external: ['react', 'redux', 'react-dom'], //Object.keys(pkg.peerDependencies || {}),
   output: {
     format: 'umd',
     name: 'ReactRedux',
     globals: {
       react: 'React',
-      redux: 'Redux'
+      redux: 'Redux',
+      'react-dom': 'ReactDOM'
     }
   },
   plugins: [
@@ -32,7 +33,8 @@ const config = {
         'node_modules/react-is/index.js': [
           'isValidElementType',
           'isContextConsumer'
-        ]
+        ],
+        'node_modules/react-dom/index.js': ['unstable_batchedUpdates']
       }
     })
   ]

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -25,6 +25,7 @@ function makeSelectorStateful(sourceSelector, store) {
   const selector = {
     run: function runComponentSelector(props) {
       try {
+        selector.lastProcessedProps = props
         const nextProps = sourceSelector(store.getState(), props)
         if (nextProps !== selector.props || selector.error) {
           selector.shouldComponentUpdate = true
@@ -286,6 +287,8 @@ export default function connectAdvanced(
 
       render() {
         const selector = this.selector
+        //forceUpdate from external
+        if (selector.lastProcessedProps !== this.props) selector.run(this.props)
         selector.shouldComponentUpdate = false
 
         //clean wrapperProps and set ref if forwardRef

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -1,11 +1,12 @@
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
 import React, { Component } from 'react'
-import { isValidElementType } from 'react-is'
+import { isValidElementType, isContextConsumer } from 'react-is'
 
 import { ReactReduxContext } from './Context'
 import Subscription from '../utils/Subscription'
 import PropTypes from 'prop-types'
+import { unstable_readContext } from '../utils/readContext'
 
 const stringifyComponent = Comp => {
   try {
@@ -88,6 +89,8 @@ export default function connectAdvanced(
     // the context consumer to use
     context = ReactReduxContext,
 
+    unstable_enableReadContextFromProps = false,
+
     // additional options are passed through to the selectorFactory
     ...connectOptions
   } = {}
@@ -157,6 +160,8 @@ export default function connectAdvanced(
 
         this.contextValueToUse = context //TODO add this.context Refresh from Provider
 
+        this.updateContextFromProps(props) //TODO refresh props.context || props.store
+
         this.contextSubscription = this.contextValueToUse.subscription
         this.store = props.store || this.contextValueToUse.store
         this.propsMode = Boolean(props.store)
@@ -170,6 +175,18 @@ export default function connectAdvanced(
 
         this.initSelector()
         this.initSubscription()
+      }
+
+      updateContextFromProps(props) {
+        if (
+          unstable_enableReadContextFromProps &&
+          props.context &&
+          props.context.Consumer &&
+          isContextConsumer(<props.context.Consumer />)
+        ) {
+          ContextToUse = props.context
+          this.contextValueToUse = unstable_readContext(props.context)
+        }
       }
 
       componentDidMount() {

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -49,10 +49,11 @@ function createListenerCollection() {
 }
 
 export default class Subscription {
-  constructor(store, parentSub) {
+  constructor(store, parentSub, onStateChange) {
     this.store = store
     this.parentSub = parentSub
     this.unsubscribe = null
+    this.onStateChange = onStateChange
     this.listeners = nullListeners
 
     this.handleChangeWrapper = this.handleChangeWrapper.bind(this)

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -1,0 +1,98 @@
+import { unstable_batchedUpdates } from 'react-dom'
+
+// encapsulates the subscription logic for connecting a component to the redux store, as
+// well as nesting subscriptions of descendant components, so that we can ensure the
+// ancestor components re-render before descendants
+
+const CLEARED = null
+const nullListeners = { notify() {} }
+
+function createListenerCollection() {
+  // the current/next pattern is copied from redux's createStore code.
+  // TODO: refactor+expose that code to be reusable here?
+  let current = []
+  let next = []
+
+  return {
+    clear() {
+      next = CLEARED
+      current = CLEARED
+    },
+
+    notify() {
+      const listeners = (current = next)
+      unstable_batchedUpdates(() => {
+        for (let i = 0; i < listeners.length; i++) {
+          listeners[i]()
+        }
+      })
+    },
+
+    get() {
+      return next
+    },
+
+    subscribe(listener) {
+      let isSubscribed = true
+      if (next === current) next = current.slice()
+      next.push(listener)
+
+      return function unsubscribe() {
+        if (!isSubscribed || current === CLEARED) return
+        isSubscribed = false
+
+        if (next === current) next = current.slice()
+        next.splice(next.indexOf(listener), 1)
+      }
+    }
+  }
+}
+
+export default class Subscription {
+  constructor(store, parentSub) {
+    this.store = store
+    this.parentSub = parentSub
+    this.unsubscribe = null
+    this.listeners = nullListeners
+
+    this.handleChangeWrapper = this.handleChangeWrapper.bind(this)
+  }
+
+  addNestedSub(listener) {
+    this.trySubscribe()
+    return this.listeners.subscribe(listener)
+  }
+
+  notifyNestedSubs() {
+    this.listeners.notify()
+  }
+
+  handleChangeWrapper() {
+    if (this.onStateChange) {
+      this.onStateChange()
+    }
+  }
+
+  isSubscribed() {
+    return Boolean(this.unsubscribe)
+  }
+
+  trySubscribe() {
+    if (!this.unsubscribe) {
+      this.unsubscribe = this.parentSub
+        ? this.parentSub.addNestedSub(this.handleChangeWrapper)
+        : this.store.subscribe(this.handleChangeWrapper)
+
+      this.listeners = createListenerCollection()
+    }
+  }
+
+  tryUnsubscribe() {
+    if (this.unsubscribe) {
+      this.unsubscribe()
+      this.unsubscribe = null
+      this.listeners.clear()
+      this.listeners = nullListeners
+    }
+  }
+}

--- a/src/utils/readContext.js
+++ b/src/utils/readContext.js
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export const unstable_readContext = Context => {
+  const s = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+  return s.ReactCurrentDispatcher.current.readContext(Context)
+}

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -19,9 +19,17 @@ describe('React', () => {
         render() {
           return (
             <ReactReduxContext.Consumer>
-              {({ storeState }) => {
+              {({ store }) => {
+                let text = ''
+
+                if (store) {
+                  text = store.getState().toString()
+                }
+
                 return (
-                  <div data-testid="store">{`${storeKey} - ${storeState}`}</div>
+                  <div data-testid="store">
+                    {storeKey} - {text}
+                  </div>
                 )
               }}
             </ReactReduxContext.Consumer>

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -4,7 +4,6 @@ import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import { createStore } from 'redux'
 import { Provider, connect } from '../../src/index.js'
-import { ReactReduxContext } from '../../src/components/Context'
 import * as rtl from 'react-testing-library'
 import 'jest-dom/extend-expect'
 
@@ -18,26 +17,14 @@ describe('React', () => {
       class Child extends Component {
         render() {
           return (
-            <ReactReduxContext.Consumer>
-              {({ store }) => {
-                let text = ''
-
-                if (store) {
-                  text = store.getState().toString()
-                }
-
-                return (
-                  <div data-testid="store">
-                    {storeKey} - {text}
-                  </div>
-                )
-              }}
-            </ReactReduxContext.Consumer>
+            <div data-testid="store">
+              {storeKey} - {this.props.text}
+            </div>
           )
         }
       }
 
-      return Child
+      return connect(s => ({ text: s }))(Child)
     }
     const Child = createChild()
 

--- a/test/components/Provider.spec.js
+++ b/test/components/Provider.spec.js
@@ -158,7 +158,12 @@ describe('React', () => {
       expect(innerMapStateToProps).toHaveBeenCalledTimes(2)
     })
 
-    it('should pass state consistently to mapState', () => {
+    /*
+      //this test is removed because now storeValue is not propagated via Context
+        so even if mapState is running 2 times on Child, the rendering is batched
+        and so Done one time only with correct ownProps
+        //
+     it('should pass state consistently to mapState', () => {
       function stringBuilder(prev = '', action) {
         return action.type === 'APPEND' ? prev + action.body : prev
       }
@@ -224,7 +229,7 @@ describe('React', () => {
         ['acbd', 'acbd'] // then store update is processed
       ])
       expect(childMapStateInvokes).toBe(4)
-    })
+    })*/
 
     it('works in <StrictMode> without warnings (React 16.3+)', () => {
       if (!React.StrictMode) {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1943,7 +1943,13 @@ describe('React', () => {
       expect(tester.getByTestId('statefulValue')).toHaveTextContent('bar')
     })
 
-    it('should pass state consistently to mapState', () => {
+    /*
+     //this test is removed because now storeValue is not propagated via Context
+        so even if mapState is running 2 times on Child, the rendering is batched
+        and so Done one time only with correct ownProps
+        //
+
+   it('should pass state consistently to mapState', () => {
       const store = createStore(stringBuilder)
 
       rtl.act(() => {
@@ -2013,7 +2019,7 @@ describe('React', () => {
         ['acb', 'acb'],
         ['acbd', 'acbd']
       ])
-    })
+    })*/
 
     it('should not render the wrapped component when mapState does not produce change', () => {
       const store = createStore(stringBuilder)

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -102,7 +102,7 @@ describe('React', () => {
       if (React.memo) {
         const store = createStore(() => ({ hi: 'there' }))
 
-        const Container = React.memo(props => <Passthrough {...props} />)
+        const Container = React.memo(props => <Passthrough {...props} />) //eslint-disable-line
         const WrappedContainer = connect(state => state)(Container)
 
         const tester = rtl.render(

--- a/test/integration/server-rendering.spec.js
+++ b/test/integration/server-rendering.spec.js
@@ -81,7 +81,7 @@ describe('React', () => {
         </Provider>
       )
 
-      expect(markup).toContain('Hello world')
+      expect(markup).toContain('<div>Hi world</div>')
       expect(store.getState().greeting).toContain('Hi')
     })
 

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,7 +1,7 @@
 const npmRun = require('npm-run')
 const fs = require('fs')
 const path = require('path')
-const LATEST_VERSION = '16.6'
+const LATEST_VERSION = '16.8'
 const version = process.env.REACT || LATEST_VERSION
 
 let jestConfig = {


### PR DESCRIPTION
### Abstract
This PR should fix performance issue with new 6.x, and restore it to 5.x speed 

- ### Remove getDerivatedStateFromProps

First of all we should have a look to React Internals: 

```javascript
// Invokes the update life-cycles and returns false if it shouldn't rerender.
function updateClassInstance(current, workInProgress, ctor, newProps, renderExpirationTime) {
  var instance = workInProgress.stateNode;

 //...................

  if (typeof getDerivedStateFromProps === 'function') {
    applyDerivedStateFromProps(workInProgress, ctor, getDerivedStateFromProps, newProps);
    newState = workInProgress.memoizedState;
  }

  var shouldUpdate = checkHasForceUpdateAfterProcessing() || checkShouldComponentUpdate(workInProgress, ctor, oldProps, newProps, oldState, newState, nextContext);

  /// ......

  return shouldUpdate;
}
```

so we can replace
```javascript
static getDerivedStateFromProps (nextProps){
   doSomeCalculationAndMemoizeToFakeState(nextProps)
}
 ```
with 
```javascript
shouldComponentUpdate(nextProps) {
     let update false;
        if (nextProps !== this.props)  {
            update = doSomeCalculation(nextProps)
         }
        return update
      }
```
that for react-redux use case (calculate new mapStateToProps when ownProps may have changed),
is safe.

- ### use static contestType propagation => no double wrapper 
With this pr i have removed double wrapper for context propagation and i use only static class contextType.

**Constraints :** 
**_Custom context can be assigned only on connect options_** 
```javascript
connect(mapState,mapDispat, { context:CustomContext })(Component)
```
tbh i think that context on props should be removed as it  is a duplication of connect options.

Anyway there are some alternative 💯 
1)Just use a different ConnectedComponet for every context you need, like:
```javascript
const MyConnectedComponentWithContext1= connect(mapState,mapDispat, { context:CustomContext1 })(Component)
const MyConnectedComponentWithContext2= connect(mapState,mapDispat, { context:CustomContext2 })(Component)
```
2) use read_context from ReactInternals to allow use context as props on 
```javascript
<ConnectedComponent context={CustomContext} />
```
you can activate it with unstable_enableReadContextFromProps = true  on connect options

```javascript
const ConnectedComponent = connect(mapState,mapDisp, { unstable_enableReadContextFromProps:true })(Component)
```
I already use it successfully  on https://github.com/salvoravida/react-universal-hooks
for `useClassContext` (useContext for classes) here https://github.com/salvoravida/react-class-hooks/blob/master/src/core/useClassContext.js

```
Results for benchmark deeptree:
┌───────────────┬─────────┬──────────────┬───────────┬───────────┬──────────┬────────────────┐
│ Version       │ Avg FPS │ Render       │ Scripting │ Rendering │ Painting │ FPS Values     │
│               │         │ (Mount, Avg) │           │           │          │                │
├───────────────┼─────────┼──────────────┼───────────┼───────────┼──────────┼────────────────┤
│ 5.1.1         │ 29.72   │ 69.3, 0.0    │ 2926.76   │ 1231.81   │ 516.42   │ 29,30,31,31    │
├───────────────┼─────────┼──────────────┼───────────┼───────────┼──────────┼────────────────┤
│ 5.2.1         │ 59.36   │ 68.9, 1.0    │ 1487.73   │ 1902.74   │ 970.93   │ 60,59,60,60    │
├───────────────┼─────────┼──────────────┼───────────┼───────────┼──────────┼────────────────┤
│ 6.0.0         │ 28.04   │ 66.8, 2.1    │ 3065.45   │ 1200.56   │ 436.10   │ 27,29,28,29,29 │
├───────────────┼─────────┼──────────────┼───────────┼───────────┼──────────┼────────────────┤
│ 6.0.1-classes │ 26.00   │ 71.2, 1.5    │ 2989.46   │ 1135.38   │ 522.30   │ 26,26          │
├───────────────┼─────────┼──────────────┼───────────┼───────────┼──────────┼────────────────┤
│ 6.2.1         │ 59.36   │ 68.6, 1.0    │ 1429.56   │ 1906.84   │ 989.53   │ 60,59,60,60    │
├───────────────┼─────────┼──────────────┼───────────┼───────────┼──────────┼────────────────┤
│ 7.0.0.alpha-3 │ 59.68   │ 73.1, 1.1    │ 1606.08   │ 1863.47   │ 945.96   │ 60,59,60,60    │
└───────────────┴─────────┴──────────────┴───────────┴───────────┴──────────┴────────────────┘
```
Test Suites: 5 passed, 5 total

- ### React peer version >16.6.0 (static contextType) 

if you want to test this PR right now you can use Yarn alias npm
```
   "react-redux": "npm:@salvoravida/react-redux@^6.2.1"
```
Your feedback is highly appreciated .... :D