### PR TITLE
[FIX]: #1219 Save references before update

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -330,6 +330,13 @@ export default function connectAdvanced(
           if (newChildProps === lastChildProps.current) {
             notifyNestedSubs()
           } else {
+            // Save references to the new child props.  Note that we track the "child props from store update"
+            // as a ref instead of a useState/useReducer because we need a way to determine if that value has
+            // been processed.  If this went into useState/useReducer, we couldn't clear out the value without
+            // forcing another re-render, which we don't want.
+            lastChildProps.current = newChildProps
+            childPropsFromStoreUpdate.current = newChildProps
+
             // If the child props _did_ change (or we caught an error), this wrapper component needs to re-render
             forceComponentUpdateDispatch({
               type: 'STORE_UPDATED',
@@ -338,13 +345,6 @@ export default function connectAdvanced(
                 error
               }
             })
-
-            // Save references to the new child props.  Note that we track the "child props from store update"
-            // as a ref instead of a useState/useReducer because we need a way to determine if that value has
-            // been processed.  If this went into useState/useReducer, we couldn't clear out the value without
-            // forcing another re-render, which we don't want.
-            lastChildProps.current = newChildProps
-            childPropsFromStoreUpdate.current = newChildProps
           }
         }
 


### PR DESCRIPTION
I will create the corresponding test ASAP. But I'm quite confident that this fixes #1219

## Update

This is what is happening:

Most of the times the update triggered by invoking the `dispatch` of `forceComponentUpdateDispatch` happens "asynchronously" (in the next event loop). However, in other instances it happens synchronously.

When it happens asynchronously, everything works as expected because the references are being updated before the next render. However, in those rare cases where the update happens immediately, the references have not being updated before the next render, which causes the following block:

```js
        if (
          childPropsFromStoreUpdate.current &&
          wrapperProps === lastWrapperProps.current
        ) {
          return childPropsFromStoreUpdate.current
        }
```

To return the same `actualChildProps` that were evaluated in the previous render. Therefore, the `useMemo` hook of `renderedChild` does not evaluate its compute function... That's why in those rare instances there is no update until the next dispatch.

Mutating the references before the dispatch fixes the issue.

The problem is that I can't find a way to create a test that reproduces this behavior :disappointed: Maybe it's because I'm tired (I'm in CEST and it's almost 5am). So, I will go get some rest and see if tomorrow I can find a way to add a test for this... But that would be testing an implementation detail, so I'm not even sure that a proper test for this bug exists. Maybe tomorrow I will see it differently...

The only thing that I'm sure of is that while this change can not break anything, it can fix #1219. So, IMHO it's save to merge it.