### PR TITLE
downgrading peer dependency to 16.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Performant and flexible.
 
 ## Installation
 
-React Redux requires **React 16.8.4 or later.**
+React Redux requires **React 16.8.0 or later.**
 
 ```
 npm install --save react-redux

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^16.8.4",
+    "react": "^16.8.0",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
   },
   "dependencies": {

--- a/test/react/16.8/package.json
+++ b/test/react/16.8/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "devDependencies": {
     "create-react-class": "^15.6.3",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "dependencies": {
     "jest-dom": "^3.1.2",


### PR DESCRIPTION
Looking at the [changelog for `React`](https://github.com/facebook/react/blob/master/CHANGELOG.md), I do not see why `react-redux` cannot have a more lenient peer dependency version.

This can be released in a `patch` release as it is a more expansive peer dependency range.

Without this change, `react-beautiful-dnd` would need to have a react peer dependency of `^16.8.4` to avoid potential warnings. Otherwise, it could use `^16.8.0`