### PR TITLE
Export subscription to improve extensibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,17 @@ import connectAdvanced from './components/connectAdvanced'
 import { ReactReduxContext } from './components/Context'
 import connect from './connect/connect'
 
+import Subscription from './utils/Subscription'
 import { setBatch } from './utils/batch'
 import { unstable_batchedUpdates as batch } from './utils/reactBatchedUpdates'
 
 setBatch(batch)
 
-export { Provider, connectAdvanced, ReactReduxContext, connect, batch }
+export {
+  Provider,
+  connectAdvanced,
+  ReactReduxContext,
+  connect,
+  batch,
+  Subscription
+}


### PR DESCRIPTION
There are some cases where it's beneficial to define your own `Provider`, which defines custom logic for store subscription.

For example if your RN app uses native navigation (https://github.com/wix/react-native-navigation), there is no point maintaining store subscription for components which are no longer on screen. Therefore it's beneficial to unsubscribe when screen _disappears_ but it's still mounted.

In order to build your own Provider one needs to have access to `Subscription` class.