### PR TITLE
Bumped required React version in documentation

### DIFF
--- a/website/versioned_docs/version-7.x/introduction/quick-start.md
+++ b/website/versioned_docs/version-7.x/introduction/quick-start.md
@@ -12,7 +12,7 @@ original_id: quick-start
 
 ## Installation
 
-React Redux 6.x requires **React 16.4 or later.**
+React Redux 7.x requires **React 16.8.4 or later.**
 
 To use React Redux with your React app:
 


### PR DESCRIPTION
Per  issue https://github.com/reduxjs/react-redux/issues/1237, the version 7.x docs weren't showing the correct required version of React.

The React peer dep was bumped a week ago here https://github.com/reduxjs/react-redux/commit/fa5857281a37545c7c036fb2499159b865b1c57d so I bumped the docs to reflect the latest peer dep.
