### PR TITLE
Lower react peer dependency to ^16.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Performant and flexible.
 
 ## Installation
 
-React Redux requires **React 16.8.4 or later.**
+React Redux requires **React 16.8.3 or later.**
 
 ```
 npm install --save react-redux

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^16.8.4",
+    "react": "^16.8.3",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
   },
   "dependencies": {

--- a/website/versioned_docs/version-7.x/introduction/quick-start.md
+++ b/website/versioned_docs/version-7.x/introduction/quick-start.md
@@ -12,7 +12,7 @@ original_id: quick-start
 
 ## Installation
 
-React Redux 7.x requires **React 16.8.4 or later.**
+React Redux 7.x requires **React 16.8.3 or later.**
 
 To use React Redux with your React app:
 


### PR DESCRIPTION
This PR lowers the `react` peer dependency from `^16.8.4` to `^16.8.3`. This is useful for React Native users, since the `react` peer dependency in `react-native` is [exactly `16.8.3`.](https://github.com/facebook/react-native/blob/master/package.json#L86)

This should have no effect on existing v7 users, but does open up new users to DevTools potentially crashing if they aren't on `react@^16.8.4`.