### PR TITLE
add react hooks for accessing redux store state and dispatching redux actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
     "clean": "rimraf lib dist es coverage",
     "format": "prettier --write \"{src,test}/**/*.{js,ts}\" index.d.ts \"docs/**/*.md\"",
-    "lint": "eslint src test/utils test/components",
+    "lint": "eslint src test/utils test/components test/hooks",
     "prepare": "npm run clean && npm run build",
     "pretest": "npm run lint",
     "test": "jest",

--- a/src/alternate-renderers.js
+++ b/src/alternate-renderers.js
@@ -3,9 +3,26 @@ import connectAdvanced from './components/connectAdvanced'
 import { ReactReduxContext } from './components/Context'
 import connect from './connect/connect'
 
+import { useActions } from './hooks/useActions'
+import { useDispatch } from './hooks/useDispatch'
+import { useReduxContext } from './hooks/useReduxContext'
+import { useSelector } from './hooks/useSelector'
+import { useStore } from './hooks/useStore'
+
 import { getBatch } from './utils/batch'
 
 // For other renderers besides ReactDOM and React Native, use the default noop batch function
 const batch = getBatch()
 
-export { Provider, connectAdvanced, ReactReduxContext, connect, batch }
+export {
+  Provider,
+  connectAdvanced,
+  ReactReduxContext,
+  connect,
+  batch,
+  useActions,
+  useDispatch,
+  useReduxContext,
+  useSelector,
+  useStore
+}

--- a/src/alternate-renderers.js
+++ b/src/alternate-renderers.js
@@ -5,7 +5,6 @@ import connect from './connect/connect'
 
 import { useActions } from './hooks/useActions'
 import { useDispatch } from './hooks/useDispatch'
-import { useReduxContext } from './hooks/useReduxContext'
 import { useSelector } from './hooks/useSelector'
 import { useStore } from './hooks/useStore'
 
@@ -22,7 +21,6 @@ export {
   batch,
   useActions,
   useDispatch,
-  useReduxContext,
   useSelector,
   useStore
 }

--- a/src/alternate-renderers.js
+++ b/src/alternate-renderers.js
@@ -5,6 +5,7 @@ import connect from './connect/connect'
 
 import { useActions } from './hooks/useActions'
 import { useDispatch } from './hooks/useDispatch'
+import { useRedux } from './hooks/useRedux'
 import { useSelector } from './hooks/useSelector'
 import { useStore } from './hooks/useStore'
 
@@ -21,6 +22,7 @@ export {
   batch,
   useActions,
   useDispatch,
+  useRedux,
   useSelector,
   useStore
 }

--- a/src/hooks/useActions.js
+++ b/src/hooks/useActions.js
@@ -1,0 +1,74 @@
+import { bindActionCreators } from 'redux'
+import invariant from 'invariant'
+import { useDispatch } from './useDispatch'
+import { useMemo } from 'react'
+
+/**
+ * A hook to bind action creators to the redux store's `dispatch` function
+ * similar to how redux's `bindActionCreators` works.
+ * 
+ * Supports passing a single action creator, an array/tuple of action
+ * creators, or an object of action creators.
+ * 
+ * Any arguments passed to the created callbacks are passed through to
+ * the your functions.
+ * 
+ * This hook takes a dependencies array as an optional second argument,
+ * which when passed ensures referential stability of the created callbacks.
+ * 
+ * @param {Function|Function[]|Object.<string, Function>} actions the action creators to bind
+ * @param {any[]} deps (optional) dependencies array to control referential stability
+ * 
+ * @returns {Function|Function[]|Object.<string, Function>} callback(s) bound to store's `dispatch` function
+ *
+ * Usage:
+ *
+```jsx
+import React from 'react'
+import { useActions } from 'react-redux'
+
+const increaseCounter = ({ amount }) => ({
+  type: 'increase-counter',
+  amount,
+})
+
+export const CounterComponent = ({ value }) => {
+  // supports passing an object of action creators
+  const { increaseCounterByOne, increaseCounterByTwo } = useActions({
+    increaseCounterByOne: () => increaseCounter(1),
+    increaseCounterByTwo: () => increaseCounter(2),
+  }, [])
+
+  // supports passing an array/tuple of action creators
+  const [increaseCounterByThree, increaseCounterByFour] = useActions([
+    () => increaseCounter(3),
+    () => increaseCounter(4),
+  ], [])
+
+  // supports passing a single action creator
+  const increaseCounterBy5 = useActions(() => increaseCounter(5), [])
+
+  // passes through any arguments to the callback
+  const increaseCounterByX = useActions(x => increaseCounter(x), [])
+
+  return (
+    <div>
+      <span>{value}</span>
+      <button onClick={increaseCounterByOne}>Increase counter by 1</button>
+    </div>
+  )
+}
+```
+ */
+export function useActions(actions, deps) {
+  invariant(actions, `You must pass actions to useActions`)
+
+  const dispatch = useDispatch()
+  return useMemo(() => {
+    if (Array.isArray(actions)) {
+      return actions.map(a => bindActionCreators(a, dispatch))
+    }
+
+    return bindActionCreators(actions, dispatch)
+  }, deps)
+}

--- a/src/hooks/useDispatch.js
+++ b/src/hooks/useDispatch.js
@@ -1,0 +1,31 @@
+import { useStore } from './useStore'
+
+/**
+ * A hook to access the redux `dispatch` function. Note that in most cases where you
+ * might want to use this hook it is recommended to use `useActions` instead to bind
+ * action creators to the `dispatch` function.
+ * 
+ * @returns {any} redux store's `dispatch` function
+ *
+ * Usage:
+ *
+```jsx
+import React, { useCallback } from 'react'
+import { useReduxDispatch } from 'react-redux'
+
+export const CounterComponent = ({ value }) => {
+  const dispatch = useDispatch()
+  const increaseCounter = useCallback(() => dispatch({ type: 'increase-counter' }), [])
+  return (
+    <div>
+      <span>{value}</span>
+      <button onClick={increaseCounter}>Increase counter</button>
+    </div>
+  )
+}
+```
+ */
+export function useDispatch() {
+  const store = useStore()
+  return store.dispatch
+}

--- a/src/hooks/useRedux.js
+++ b/src/hooks/useRedux.js
@@ -1,0 +1,40 @@
+import { useSelector } from './useSelector'
+import { useActions } from './useActions'
+
+/**
+ * A hook to access the redux store's state and to bind action creators to 
+ * the store's dispatch function. In essence, this hook is a combination of
+ * `useSelector` and `useActions`.
+ * 
+ * @param {Function} selector the selector function
+ * @param {Function|Function[]|Object.<string, Function>} actions the action creators to bind
+ * 
+ * @returns {[any, any]} a tuple of the selected state and the bound action creators
+ *
+ * Usage:
+ *
+```jsx
+import React from 'react'
+import { useRedux } from 'react-redux'
+
+export const CounterComponent = () => {
+  const [counter, { inc1, inc }] = useRedux(state => state.counter, {
+    inc1: () => ({ type: 'inc1' }),
+    inc: amount => ({ type: 'inc', amount }),
+  })
+
+  return (
+    <>
+      <div>
+        {counter}
+      </div>
+      <button onClick={inc1}>Increment by 1</button>
+      <button onClick={() => inc(5)}>Increment by 5</button>
+    </>
+  )
+}
+```
+ */
+export function useRedux(selector, actions) {
+  return [useSelector(selector), useActions(actions)]
+}

--- a/src/hooks/useReduxContext.js
+++ b/src/hooks/useReduxContext.js
@@ -1,0 +1,32 @@
+import { useContext } from 'react'
+import invariant from 'invariant'
+import { ReactReduxContext } from '../components/Context'
+
+/**
+ * A hook to access the value of the `ReactReduxContext`. This is a low-level
+ * hook that you should usually not need to call directly.
+ * 
+ * @returns {any} the value of the `ReactReduxContext`
+ *
+ * Usage:
+ *
+```jsx
+import React from 'react'
+import { useReduxContext } from 'react-redux'
+
+export const CounterComponent = ({ value }) => {
+  const { store } = useReduxContext()
+  return <div>{store.getState()}</div>
+}
+```
+ */
+export function useReduxContext() {
+  const contextValue = useContext(ReactReduxContext)
+
+  invariant(
+    contextValue,
+    'could not find react-redux context value; please ensure the component is wrapped in a <Provider>'
+  )
+
+  return contextValue
+}

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -1,0 +1,87 @@
+import { useReducer, useRef, useEffect, useMemo, useLayoutEffect } from 'react'
+import invariant from 'invariant'
+import { useReduxContext } from './useReduxContext'
+import shallowEqual from '../utils/shallowEqual'
+import Subscription from '../utils/Subscription'
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser. We need useLayoutEffect to ensure the store
+// subscription callback always has the selector from the latest render commit
+// available, otherwise a store update may happen between render and the effect,
+// which may cause missed updates; we also must ensure the store subscription
+// is created synchronously, otherwise a store update may occur before the
+// subscription is created and an inconsistent state may be observed
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+
+/**
+ * A hook to access the redux store's state. This hook takes a selector function
+ * as an argument. The selector is called with the store state.
+ * 
+ * @param {Function} selector the selector function
+ * 
+ * @returns {any} the selected state
+ *
+ * Usage:
+ *
+```jsx
+import React from 'react'
+import { useSelector } from 'react-redux'
+
+export const CounterComponent = () => {
+  const counter = useSelector(state => state.counter)
+  return <div>{counter}</div>
+}
+```
+ */
+export function useSelector(selector) {
+  invariant(selector, `You must pass a selector to useSelectors`)
+
+  const { store, subscription: contextSub } = useReduxContext()
+  const [, forceRender] = useReducer(s => s + 1, 0)
+
+  const subscription = useMemo(() => new Subscription(store, contextSub), [
+    store,
+    contextSub
+  ])
+
+  const latestSelector = useRef(selector)
+  const selectedState = selector(store.getState())
+  const latestSelectedState = useRef(selectedState)
+
+  useIsomorphicLayoutEffect(() => {
+    latestSelector.current = selector
+    latestSelectedState.current = selectedState
+  })
+
+  useIsomorphicLayoutEffect(() => {
+    function checkForUpdates() {
+      try {
+        const newSelectedState = latestSelector.current(store.getState())
+
+        if (shallowEqual(newSelectedState, latestSelectedState.current)) {
+          return
+        }
+
+        latestSelectedState.current = newSelectedState
+      } catch {
+        // we ignore all errors here, since when the component
+        // is re-rendered, the selectors are called again, and
+        // will throw again, if neither props nor store state
+        // changed
+      }
+
+      forceRender({})
+    }
+
+    subscription.onStateChange = checkForUpdates
+    subscription.trySubscribe()
+
+    checkForUpdates()
+
+    return () => subscription.tryUnsubscribe()
+  }, [store, subscription])
+
+  return selectedState
+}

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -1,0 +1,23 @@
+import { useReduxContext } from './useReduxContext'
+
+/**
+ * A hook to access the redux store.
+ * 
+ * @returns {any} the redux store
+ *
+ * Usage:
+ *
+```jsx
+import React from 'react'
+import { useStore } from 'react-redux'
+
+export const CounterComponent = ({ value }) => {
+  const store = useStore()
+  return <div>{store.getState()}</div>
+}
+```
+ */
+export function useStore() {
+  const { store } = useReduxContext()
+  return store
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,26 @@ import connectAdvanced from './components/connectAdvanced'
 import { ReactReduxContext } from './components/Context'
 import connect from './connect/connect'
 
+import { useActions } from './hooks/useActions'
+import { useDispatch } from './hooks/useDispatch'
+import { useReduxContext } from './hooks/useReduxContext'
+import { useSelector } from './hooks/useSelector'
+import { useStore } from './hooks/useStore'
+
 import { setBatch } from './utils/batch'
 import { unstable_batchedUpdates as batch } from './utils/reactBatchedUpdates'
 
 setBatch(batch)
 
-export { Provider, connectAdvanced, ReactReduxContext, connect, batch }
+export {
+  Provider,
+  connectAdvanced,
+  ReactReduxContext,
+  connect,
+  batch,
+  useActions,
+  useDispatch,
+  useReduxContext,
+  useSelector,
+  useStore
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import connect from './connect/connect'
 
 import { useActions } from './hooks/useActions'
 import { useDispatch } from './hooks/useDispatch'
-import { useReduxContext } from './hooks/useReduxContext'
 import { useSelector } from './hooks/useSelector'
 import { useStore } from './hooks/useStore'
 
@@ -22,7 +21,6 @@ export {
   batch,
   useActions,
   useDispatch,
-  useReduxContext,
   useSelector,
   useStore
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import connect from './connect/connect'
 
 import { useActions } from './hooks/useActions'
 import { useDispatch } from './hooks/useDispatch'
+import { useRedux } from './hooks/useRedux'
 import { useSelector } from './hooks/useSelector'
 import { useStore } from './hooks/useStore'
 
@@ -21,6 +22,7 @@ export {
   batch,
   useActions,
   useDispatch,
+  useRedux,
   useSelector,
   useStore
 }

--- a/test/hooks/useActions.spec.js
+++ b/test/hooks/useActions.spec.js
@@ -1,0 +1,178 @@
+import React from 'react'
+import { createStore } from 'redux'
+import * as rtl from 'react-testing-library'
+import { Provider as ProviderMock, useActions } from '../../src/index.js'
+
+describe('React', () => {
+  describe('hooks', () => {
+    describe(useActions.name, () => {
+      let store
+      let dispatchedActions = []
+
+      beforeEach(() => {
+        const reducer = (state = 0, action) => {
+          dispatchedActions.push(action)
+
+          if (action.type === 'inc1') {
+            return state + 1
+          }
+
+          if (action.type === 'inc') {
+            return state + action.amount
+          }
+
+          return state
+        }
+
+        store = createStore(reducer)
+        dispatchedActions = []
+      })
+
+      afterEach(() => rtl.cleanup())
+
+      it('supports a single action creator', () => {
+        const Comp = () => {
+          const inc1 = useActions(() => ({ type: 'inc1' }))
+
+          return (
+            <>
+              <button id="bInc1" onClick={inc1} />
+            </>
+          )
+        }
+
+        const { container } = rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        const bInc1 = container.querySelector('#bInc1')
+
+        rtl.fireEvent.click(bInc1)
+
+        expect(dispatchedActions).toEqual([{ type: 'inc1' }])
+      })
+
+      it('supports an object of action creators', () => {
+        const Comp = () => {
+          const { inc1, inc2 } = useActions({
+            inc1: () => ({ type: 'inc1' }),
+            inc2: () => ({ type: 'inc', amount: 2 })
+          })
+
+          return (
+            <>
+              <button id="bInc1" onClick={inc1} />
+              <button id="bInc2" onClick={inc2} />
+            </>
+          )
+        }
+
+        const { container } = rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        const bInc1 = container.querySelector('#bInc1')
+        const bInc2 = container.querySelector('#bInc2')
+
+        rtl.fireEvent.click(bInc1)
+        rtl.fireEvent.click(bInc2)
+
+        expect(dispatchedActions).toEqual([
+          { type: 'inc1' },
+          { type: 'inc', amount: 2 }
+        ])
+      })
+
+      it('supports an array of action creators', () => {
+        const Comp = () => {
+          const [inc1, inc2] = useActions([
+            () => ({ type: 'inc1' }),
+            () => ({ type: 'inc', amount: 2 })
+          ])
+
+          return (
+            <>
+              <button id="bInc1" onClick={inc1} />
+              <button id="bInc2" onClick={inc2} />
+            </>
+          )
+        }
+
+        const { container } = rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        const bInc1 = container.querySelector('#bInc1')
+        const bInc2 = container.querySelector('#bInc2')
+
+        rtl.fireEvent.click(bInc1)
+        rtl.fireEvent.click(bInc2)
+
+        expect(dispatchedActions).toEqual([
+          { type: 'inc1' },
+          { type: 'inc', amount: 2 }
+        ])
+      })
+
+      it('passes through arguments', () => {
+        const reducer = (state = 0, action) => {
+          dispatchedActions.push(action)
+          if (action.type === 'adjust') {
+            return action.isAdd ? state + action.amount : state - action.amount
+          }
+
+          return state
+        }
+
+        const store = createStore(reducer)
+        dispatchedActions = []
+
+        const Comp = () => {
+          const { adjust } = useActions({
+            adjust: (amount, isAdd = true) => ({
+              type: 'adjust',
+              amount,
+              isAdd
+            })
+          })
+
+          return (
+            <>
+              <button id="bInc1" onClick={() => adjust(1)} />
+              <button id="bInc2" onClick={() => adjust(2)} />
+              <button id="bDec1" onClick={() => adjust(1, false)} />
+            </>
+          )
+        }
+
+        const { container } = rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        const bInc1 = container.querySelector('#bInc1')
+        const bInc2 = container.querySelector('#bInc2')
+        const bDec1 = container.querySelector('#bDec1')
+
+        rtl.fireEvent.click(bInc1)
+        rtl.fireEvent.click(bInc2)
+        rtl.fireEvent.click(bDec1)
+
+        expect(dispatchedActions).toEqual([
+          { type: 'adjust', amount: 1, isAdd: true },
+          { type: 'adjust', amount: 2, isAdd: true },
+          { type: 'adjust', amount: 1, isAdd: false }
+        ])
+      })
+
+      // TODO: test for deps
+    })
+  })
+})

--- a/test/hooks/useActions.spec.js
+++ b/test/hooks/useActions.spec.js
@@ -5,7 +5,7 @@ import { Provider as ProviderMock, useActions } from '../../src/index.js'
 
 describe('React', () => {
   describe('hooks', () => {
-    describe(useActions.name, () => {
+    describe('useActions', () => {
       let store
       let dispatchedActions = []
 

--- a/test/hooks/useDispatch.spec.js
+++ b/test/hooks/useDispatch.spec.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { createStore } from 'redux'
+import * as rtl from 'react-testing-library'
+import { Provider as ProviderMock, useDispatch } from '../../src/index.js'
+
+const store = createStore(c => c + 1)
+
+describe('React', () => {
+  describe('hooks', () => {
+    describe(useDispatch.name, () => {
+      afterEach(() => rtl.cleanup())
+
+      it("returns the store's dispatch function", () => {
+        let dispatch
+
+        const Comp = () => {
+          dispatch = useDispatch()
+          return <div />
+        }
+
+        rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        expect(dispatch).toBe(store.dispatch)
+      })
+    })
+  })
+})

--- a/test/hooks/useDispatch.spec.js
+++ b/test/hooks/useDispatch.spec.js
@@ -7,7 +7,7 @@ const store = createStore(c => c + 1)
 
 describe('React', () => {
   describe('hooks', () => {
-    describe(useDispatch.name, () => {
+    describe('useDispatch', () => {
       afterEach(() => rtl.cleanup())
 
       it("returns the store's dispatch function", () => {

--- a/test/hooks/useRedux.spec.js
+++ b/test/hooks/useRedux.spec.js
@@ -1,0 +1,51 @@
+/*eslint-disable react/prop-types*/
+
+import React from 'react'
+import { createStore } from 'redux'
+import * as rtl from 'react-testing-library'
+import { Provider as ProviderMock, useRedux } from '../../src/index.js'
+
+describe('React', () => {
+  describe('hooks', () => {
+    describe(useRedux.name, () => {
+      let store
+      let renderedItems = []
+
+      beforeEach(() => {
+        store = createStore(({ count } = { count: -1 }) => ({
+          count: count + 1
+        }))
+        renderedItems = []
+      })
+
+      afterEach(() => rtl.cleanup())
+
+      it('selects the state and binds action creators', () => {
+        const Comp = () => {
+          const [count, { inc }] = useRedux(s => s.count, {
+            inc: () => ({ type: '' })
+          })
+          renderedItems.push(count)
+          return (
+            <>
+              <div>{count}</div>
+              <button id="bInc" onClick={inc} />
+            </>
+          )
+        }
+
+        const { container } = rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        const bInc = container.querySelector('#bInc')
+
+        rtl.fireEvent.click(bInc)
+
+        expect(renderedItems).toEqual([0, 1])
+      })
+    })
+  })
+})

--- a/test/hooks/useRedux.spec.js
+++ b/test/hooks/useRedux.spec.js
@@ -7,7 +7,7 @@ import { Provider as ProviderMock, useRedux } from '../../src/index.js'
 
 describe('React', () => {
   describe('hooks', () => {
-    describe(useRedux.name, () => {
+    describe('useRedux', () => {
       let store
       let renderedItems = []
 

--- a/test/hooks/useReduxContext.spec.js
+++ b/test/hooks/useReduxContext.spec.js
@@ -4,7 +4,7 @@ import { useReduxContext } from '../../src/hooks/useReduxContext'
 
 describe('React', () => {
   describe('hooks', () => {
-    describe(useReduxContext.name, () => {
+    describe('useReduxContext', () => {
       afterEach(() => rtl.cleanup())
 
       it('throws if component is not wrapped in provider', () => {

--- a/test/hooks/useReduxContext.spec.js
+++ b/test/hooks/useReduxContext.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import * as rtl from 'react-testing-library'
-import { useReduxContext } from '../../src/index.js'
+import { useReduxContext } from '../../src/hooks/useReduxContext'
 
 describe('React', () => {
   describe('hooks', () => {

--- a/test/hooks/useReduxContext.spec.js
+++ b/test/hooks/useReduxContext.spec.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import * as rtl from 'react-testing-library'
+import { useReduxContext } from '../../src/index.js'
+
+describe('React', () => {
+  describe('hooks', () => {
+    describe(useReduxContext.name, () => {
+      afterEach(() => rtl.cleanup())
+
+      it('throws if component is not wrapped in provider', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+        const Comp = () => {
+          useReduxContext()
+          return <div />
+        }
+
+        expect(() => rtl.render(<Comp />)).toThrow(
+          /could not find react-redux context value/
+        )
+
+        spy.mockRestore()
+      })
+    })
+  })
+})

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -1,0 +1,209 @@
+/*eslint-disable react/prop-types*/
+
+import React from 'react'
+import { createStore } from 'redux'
+import * as rtl from 'react-testing-library'
+import {
+  Provider as ProviderMock,
+  useSelector,
+  useReduxContext
+} from '../../src/index.js'
+
+describe('React', () => {
+  describe('hooks', () => {
+    describe(useSelector.name, () => {
+      let store
+      let renderedItems = []
+
+      beforeEach(() => {
+        store = createStore(({ count } = { count: -1 }) => ({
+          count: count + 1
+        }))
+        renderedItems = []
+      })
+
+      afterEach(() => rtl.cleanup())
+
+      describe('core subscription behavior', () => {
+        it('selects the state on initial render', () => {
+          const Comp = () => {
+            const count = useSelector(s => s.count)
+            renderedItems.push(count)
+            return <div>{count}</div>
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          expect(renderedItems).toEqual([0])
+        })
+
+        it('selects the state and renders the component when the store updates', () => {
+          const Comp = () => {
+            const count = useSelector(s => s.count)
+            renderedItems.push(count)
+            return <div>{count}</div>
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          store.dispatch({ type: '' })
+
+          expect(renderedItems).toEqual([0, 1])
+        })
+      })
+
+      describe('lifeycle interactions', () => {
+        it('subscribes to the store synchronously', () => {
+          let rootSubscription
+
+          const Parent = () => {
+            const { subscription } = useReduxContext()
+            rootSubscription = subscription
+            const count = useSelector(s => s.count)
+            return count === 1 ? <Child /> : null
+          }
+
+          const Child = () => {
+            const count = useSelector(s => s.count)
+            return <div>{count}</div>
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Parent />
+            </ProviderMock>
+          )
+
+          expect(rootSubscription.listeners.get().length).toBe(1)
+
+          store.dispatch({ type: '' })
+
+          expect(rootSubscription.listeners.get().length).toBe(2)
+        })
+
+        it('unsubscribes when the component is unmounted', () => {
+          let rootSubscription
+
+          const Parent = () => {
+            const { subscription } = useReduxContext()
+            rootSubscription = subscription
+            const count = useSelector(s => s.count)
+            return count === 0 ? <Child /> : null
+          }
+
+          const Child = () => {
+            const count = useSelector(s => s.count)
+            return <div>{count}</div>
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Parent />
+            </ProviderMock>
+          )
+
+          expect(rootSubscription.listeners.get().length).toBe(2)
+
+          store.dispatch({ type: '' })
+
+          expect(rootSubscription.listeners.get().length).toBe(1)
+        })
+
+        it('notices store updates between render and store subscription effect', () => {
+          const Comp = () => {
+            const count = useSelector(s => s.count)
+            renderedItems.push(count)
+
+            // I don't know a better way to trigger a store update before the
+            // store subscription effect happens
+            if (count === 0) {
+              store.dispatch({ type: '' })
+            }
+
+            return <div>{count}</div>
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          expect(renderedItems).toEqual([0, 1])
+        })
+      })
+
+      describe('performance optimizations and bail-outs', () => {
+        it('should shallowly compare the selected state to prevent unnecessary updates', () => {
+          store = createStore(
+            ({ count, stable } = { count: -1, stable: {} }) => ({
+              count: count + 1,
+              stable
+            })
+          )
+
+          const Comp = () => {
+            const value = useSelector(s => Object.keys(s))
+            renderedItems.push(value)
+            return <div />
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          expect(renderedItems.length).toBe(1)
+
+          store.dispatch({ type: '' })
+
+          expect(renderedItems.length).toBe(1)
+        })
+      })
+
+      describe('edge cases', () => {
+        it('ignores transient errors in selector (e.g. due to stale props)', () => {
+          const Parent = () => {
+            const count = useSelector(s => s.count)
+            return <Child parentCount={count} />
+          }
+
+          const Child = ({ parentCount }) => {
+            const result = useSelector(({ count }) => {
+              if (count !== parentCount) {
+                throw new Error()
+              }
+
+              return count + parentCount
+            })
+
+            return <div>{result}</div>
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Parent />
+            </ProviderMock>
+          )
+
+          expect(() => store.dispatch({ type: '' })).not.toThrowError()
+        })
+      })
+
+      describe('error handling for invalid arguments', () => {
+        it('throws if no selector is passed', () => {
+          expect(() => useSelector()).toThrow()
+        })
+      })
+    })
+  })
+})

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -8,7 +8,7 @@ import { useReduxContext } from '../../src/hooks/useReduxContext'
 
 describe('React', () => {
   describe('hooks', () => {
-    describe(useSelector.name, () => {
+    describe('useSelector', () => {
       let store
       let renderedItems = []
 

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -3,11 +3,8 @@
 import React from 'react'
 import { createStore } from 'redux'
 import * as rtl from 'react-testing-library'
-import {
-  Provider as ProviderMock,
-  useSelector,
-  useReduxContext
-} from '../../src/index.js'
+import { Provider as ProviderMock, useSelector } from '../../src/index.js'
+import { useReduxContext } from '../../src/hooks/useReduxContext'
 
 describe('React', () => {
   describe('hooks', () => {


### PR DESCRIPTION
As discussed in the [hooks API design issue](https://github.com/reduxjs/react-redux/issues/1179), here is an implementation that could be used as an alpha.

There are a couple of open points:

- are tests for HMR required? (the corresponding tests in `connect.spec.js` are skipped)
- I added inline documentation to the hooks, but other code doesn't have this (instead, the docu is in the [types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-redux/index.d.ts)); not sure what you want to do here
- I haven't updated the docs yet to mention hooks
- naming of hooks could change depending on the [API design issue](https://github.com/reduxjs/react-redux/issues/1179)