### PR TITLE
Moved react-dom to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "invariant": "^2.2.4",
     "loose-envify": "^1.4.0",
     "prop-types": "^15.7.2",
+    "react-dom": "^16.8.6",
     "react-is": "^16.8.6"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "jest-dom": "^3.1.3",
     "prettier": "^1.16.4",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "react-testing-library": "^5.9.0",
     "redux": "^4.0.1",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
With the inclusion of `{ unstable_batchedUpdates } from 'react-dom'` the `react-dom` package is now a `dependency`, as opposed to a `devDependency`.

**Problem:**
When installing with `pnpm recursive install` the `react-dom` package is not installed as a dependency for the `react-redux` package and builds using webpack will fail as the package is not available.

**Expected:**
`react-dom` should be a dependency.

**Workaround until fixed:**
Using `pnpm hooks` (https://pnpm.js.org/docs/en/hooks.html), the following `pnpmfile.js` will fix the problem by moving the dependency programmatically:
```
module.exports = {
  hooks: {
    readPackage
  }
}

function readPackage (pkg, context) {
  // react-redux@7: Move react-dom into from devDependencies to dependencies
  if (pkg.name === 'react-redux' && pkg.version.startsWith('7.')) {
    pkg.dependencies['react-dom'] = pkg.devDependencies['react-dom'];
    delete pkg.devDependencies['react-dom'];
    context.log(`react-redux@${pkg.version}: Moved react-dom from devDependencies -> dependencies`);
  }
  return pkg;
}
```