### PR TITLE
adjust the hooks docs with more details about useSelector and add some more examples

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -16,16 +16,16 @@ React's `unstable_batchedUpdate()` API allows any React updates in an event loop
 Since React-Redux needs to work in both ReactDOM and React Native environments, we've taken care of importing this API from the correct renderer at build time for our own use. We also now re-export this function publicly ourselves, renamed to `batch()`. You can use it to ensure that multiple actions dispatched outside of React only result in a single render update, like this:
 
 ```js
-import { batch } from "react-redux";
+import { batch } from 'react-redux'
 
 function myThunk() {
-    return (dispatch, getState) => {
-        // should only result in one combined re-render, not two
-        batch(() => {
-            dispatch(increment());
-            dispatch(increment());
-        })
-    }
+  return (dispatch, getState) => {
+    // should only result in one combined re-render, not two
+    batch(() => {
+      dispatch(increment())
+      dispatch(increment())
+    })
+  }
 }
 ```
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -94,20 +94,20 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import { createSelector } from 'reselect'
 
-const selectNrOfDoneTodos = createSelector(
+const selectNumOfDoneTodos = createSelector(
   state => state.todos,
   todos => todos.filter(todo => todo.isDone).length
 )
 
 export const DoneTodosCounter = () => {
-  const nrOfDoneTodos = useSelector(selectNrOfDoneTodos)
-  return <div>{nrOfDoneTodos}</div>
+  const NumOfDoneTodos = useSelector(selectNumOfDoneTodos)
+  return <div>{NumOfDoneTodos}</div>
 }
 
 export const App = () => {
   return (
     <>
-      <span>Nr of done todos:</span>
+      <span>Number of done todos:</span>
       <DoneTodosCounter />
     </>
   )
@@ -121,38 +121,38 @@ import React from 'react'
 import { useSelector } from 'react-redux'
 import { createSelector } from 'reselect'
 
-const selectNrOfTodosWithIsDoneValue = createSelector(
+const selectNumOfTodosWithIsDoneValue = createSelector(
   state => state.todos,
   (_, isDone) => isDone,
   (todos, isDone) => todos.filter(todo => todo.isDone === isDone).length
 )
 
 export const TodoCounterForIsDoneValue = ({ isDone }) => {
-  const nrOfTodosWithIsDoneValue = useSelector(state =>
-    selectNrOfTodosWithIsDoneValue(state, isDone)
+  const NumOfTodosWithIsDoneValue = useSelector(state =>
+    selectNumOfTodosWithIsDoneValue(state, isDone)
   )
 
-  return <div>{nrOfTodosWithIsDoneValue}</div>
+  return <div>{NumOfTodosWithIsDoneValue}</div>
 }
 
 export const App = () => {
   return (
     <>
-      <span>Nr of done todos:</span>
+      <span>Number of done todos:</span>
       <TodoCounterForIsDoneValue isDone={true} />
     </>
   )
 }
 ```
 
-However, when the selector is used in multiple components and depends on the component's props, you need to ensure that each component instance gets its own selector instance (see [here](https://github.com/reduxjs/reselect#accessing-react-props-in-selectors) for a more thourough explanation of why this is necessary):
+However, when the selector is used in multiple component instances and depends on the component's props, you need to ensure that each component instance gets its own selector instance (see [here](https://github.com/reduxjs/reselect#accessing-react-props-in-selectors) for a more thourough explanation of why this is necessary):
 
 ```jsx
 import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { createSelector } from 'reselect'
 
-const makeNrOfTodosWithIsDoneSelector = () =>
+const makeNumOfTodosWithIsDoneSelector = () =>
   createSelector(
     state => state.todos,
     (_, isDone) => isDone,
@@ -160,21 +160,24 @@ const makeNrOfTodosWithIsDoneSelector = () =>
   )
 
 export const TodoCounterForIsDoneValue = ({ isDone }) => {
-  const selectNrOfTodosWithIsDone = useMemo(makeNrOfTodosWithIsDoneSelector, [])
-
-  const nrOfTodosWithIsDoneValue = useSelector(state =>
-    selectNrOfTodosWithIsDoneValue(state, isDone)
+  const selectNumOfTodosWithIsDone = useMemo(
+    makeNumOfTodosWithIsDoneSelector,
+    []
   )
 
-  return <div>{nrOfTodosWithIsDoneValue}</div>
+  const NumOfTodosWithIsDoneValue = useSelector(state =>
+    selectNumOfTodosWithIsDoneValue(state, isDone)
+  )
+
+  return <div>{NumOfTodosWithIsDoneValue}</div>
 }
 
 export const App = () => {
   return (
     <>
-      <span>Nr of done todos:</span>
+      <span>Number of done todos:</span>
       <TodoCounterForIsDoneValue isDone={true} />
-      <span>Nr of unfinished todos:</span>
+      <span>Number of unfinished todos:</span>
       <TodoCounterForIsDoneValue isDone={false} />
     </>
   )


### PR DESCRIPTION
I have adjusted the hooks docs with some more details regarding `useSelector`. I have also added some more examples.

I know some of these changes may be controversial, especially since it is not always a good idea to talk too much about implementation details in the docs. However, I feel in this case it is required due to the complexity of the stale props issue.

I don't expect all of these changes to be accepted, but I would like to discuss them anyways.