### PR TITLE
Add docs for `batch()`

### DIFF
--- a/docs/api/batch.md
+++ b/docs/api/batch.md
@@ -1,0 +1,34 @@
+---
+id: batch
+title: batch
+sidebar_label: batch()
+hide_title: true
+---
+
+# `batch()`
+
+```js
+batch(fn: Function)
+```
+
+React's `unstable_batchedUpdate()` API allows any React updates in an event loop tick to be batched together into a single render pass. React already uses this internally for its own event handler callbacks. This API is actually part of the renderer packages like ReactDOM and React Native, not the React core itself.
+
+Since React-Redux needs to work in both ReactDOM and React Native environments, we've taken care of importing this API from the correct renderer at build time for our own use. We also now re-export this function publicly ourselves, renamed to `batch()`. You can use it to ensure that multiple actions dispatched outside of React only result in a single render update, like this:
+
+```js
+import { batch } from "react-redux";
+
+function myThunk() {
+    return (dispatch, getState) => {
+        // should only result in one combined re-render, not two
+        batch(() => {
+            dispatch(increment());
+            dispatch(increment());
+        })
+    }
+}
+```
+
+## References
+
+- [`unstable_batchedUpdate()` API from React](https://github.com/facebook/react/commit/b41883fc708cd24d77dcaa767cde814b50b457fe)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,10 +14,9 @@
       "api/connect",
       "api/provider",
       "api/connect-advanced",
+      "api/batch",
       "api/hooks"
     ],
-    "Guides": [
-      "troubleshooting"
-    ]
+    "Guides": ["troubleshooting"]
   }
 }

--- a/website/versioned_docs/version-7.x/api/batch.md
+++ b/website/versioned_docs/version-7.x/api/batch.md
@@ -1,0 +1,35 @@
+---
+id: version-7.x-batch
+title: batch
+sidebar_label: batch()
+hide_title: true
+original_id: batch
+---
+
+# `batch()`
+
+```js
+batch(fn: Function)
+```
+
+React's `unstable_batchedUpdate()` API allows any React updates in an event loop tick to be batched together into a single render pass. React already uses this internally for its own event handler callbacks. This API is actually part of the renderer packages like ReactDOM and React Native, not the React core itself.
+
+Since React-Redux needs to work in both ReactDOM and React Native environments, we've taken care of importing this API from the correct renderer at build time for our own use. We also now re-export this function publicly ourselves, renamed to `batch()`. You can use it to ensure that multiple actions dispatched outside of React only result in a single render update, like this:
+
+```js
+import { batch } from "react-redux";
+
+function myThunk() {
+    return (dispatch, getState) => {
+        // should only result in one combined re-render, not two
+        batch(() => {
+            dispatch(increment());
+            dispatch(increment());
+        })
+    }
+}
+```
+
+## References
+
+- [`unstable_batchedUpdate()` API from React](https://github.com/facebook/react/commit/b41883fc708cd24d77dcaa767cde814b50b457fe)

--- a/website/versioned_sidebars/version-7.x-sidebars.json
+++ b/website/versioned_sidebars/version-7.x-sidebars.json
@@ -1,0 +1,21 @@
+{
+  "version-7.x-docs": {
+    "Introduction": [
+      "version-7.x-introduction/quick-start",
+      "version-7.x-introduction/basic-tutorial",
+      "version-7.x-introduction/why-use-react-redux"
+    ],
+    "Using React Redux": [
+      "version-7.x-using-react-redux/connect-mapstate",
+      "version-7.x-using-react-redux/connect-mapdispatch",
+      "version-7.x-using-react-redux/accessing-store"
+    ],
+    "API Reference": [
+      "version-7.x-api/connect",
+      "version-7.x-api/provider",
+      "version-7.x-api/connect-advanced",
+      "version-7.x-api/batch"
+    ],
+    "Guides": ["version-7.x-troubleshooting"]
+  }
+}


### PR DESCRIPTION
What does this PR do?
---
I was reading the release notes for v7 and learned about this API. I thought it's nice to have this in the docs for people who did not read the release notes.
The docs content comes directly from the release notes.

Summary of the Changes
---
- Add `batch()` to both docs/ and v7 versioned docs
- Add versioned_sidebar for v7