### PR TITLE
Avoid unnecessary selector evaluations

### DIFF
--- a/src/alternate-renderers.js
+++ b/src/alternate-renderers.js
@@ -8,6 +8,7 @@ import { useSelector } from './hooks/useSelector'
 import { useStore } from './hooks/useStore'
 
 import { getBatch } from './utils/batch'
+import shallowEqual from './utils/shallowEqual'
 
 // For other renderers besides ReactDOM and React Native, use the default noop batch function
 const batch = getBatch()
@@ -20,5 +21,6 @@ export {
   batch,
   useDispatch,
   useSelector,
-  useStore
+  useStore,
+  shallowEqual
 }

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -50,12 +50,17 @@ export function useSelector(selector) {
   ])
 
   const latestSubscriptionCallbackError = useRef()
-  const latestSelector = useRef(selector)
+  const latestSelector = useRef()
+  const latestSelectedState = useRef()
 
-  let selectedState = undefined
+  let selectedState
 
   try {
-    selectedState = selector(store.getState())
+    selectedState =
+      selector !== latestSelector.current ||
+      latestSubscriptionCallbackError.current
+        ? selector(store.getState())
+        : latestSelectedState.current
   } catch (err) {
     let errorMessage = `An error occured while selecting the store state: ${
       err.message
@@ -69,8 +74,6 @@ export function useSelector(selector) {
 
     throw new Error(errorMessage)
   }
-
-  const latestSelectedState = useRef(selectedState)
 
   useIsomorphicLayoutEffect(() => {
     latestSelector.current = selector

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -56,11 +56,14 @@ export function useSelector(selector) {
   let selectedState
 
   try {
-    selectedState =
+    if (
       selector !== latestSelector.current ||
       latestSubscriptionCallbackError.current
-        ? selector(store.getState())
-        : latestSelectedState.current
+    ) {
+      selectedState = selector(store.getState())
+    } else {
+      selectedState = latestSelectedState.current
+    }
   } catch (err) {
     let errorMessage = `An error occured while selecting the store state: ${
       err.message

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -1,6 +1,6 @@
 /*eslint-disable react/prop-types*/
 
-import React from 'react'
+import React, { useCallback, useReducer } from 'react'
 import { createStore } from 'redux'
 import { renderHook, act } from 'react-hooks-testing-library'
 import * as rtl from 'react-testing-library'
@@ -47,6 +47,29 @@ describe('React', () => {
       })
 
       describe('lifeycle interactions', () => {
+        it('always uses the latest state', () => {
+          store = createStore(c => c + 1, -1)
+
+          const Comp = () => {
+            const selector = useCallback(c => c + 1, [])
+            const value = useSelector(selector)
+            renderedItems.push(value)
+            return <div />
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          expect(renderedItems).toEqual([1])
+
+          store.dispatch({ type: '' })
+
+          expect(renderedItems).toEqual([1, 2])
+        })
+
         it('subscribes to the store synchronously', () => {
           let rootSubscription
 
@@ -154,6 +177,39 @@ describe('React', () => {
 
           expect(renderedItems.length).toBe(1)
         })
+      })
+
+      it('uses the latest selector', () => {
+        let selectorId = 0
+        let forceRender
+
+        const Comp = () => {
+          const [, f] = useReducer(c => c + 1, 0)
+          forceRender = f
+          const renderedSelectorId = selectorId++
+          const value = useSelector(() => renderedSelectorId)
+          renderedItems.push(value)
+          return <div />
+        }
+
+        rtl.render(
+          <ProviderMock store={store}>
+            <Comp />
+          </ProviderMock>
+        )
+
+        expect(renderedItems).toEqual([0])
+
+        rtl.act(forceRender)
+        expect(renderedItems).toEqual([0, 1])
+
+        rtl.act(() => {
+          store.dispatch({ type: '' })
+        })
+        expect(renderedItems).toEqual([0, 1])
+
+        rtl.act(forceRender)
+        expect(renderedItems).toEqual([0, 1, 2])
       })
 
       describe('edge cases', () => {


### PR DESCRIPTION
Hi,

While I was working on #1272 I noticed that the selector was being evaluated more times than what's necessary. This PR makes sure that the selector is only evaluated when it's strictly needed.

cc: @MrWolfZ I would really appreciate you having a look at this, just to make sure that I didn't miss anything. All the previous tests are passing, and I have also added a new one to make sure that updating the selector works correctly. Please let me know what you think. Thanks!

## Edit

A couple of things that I forgot to mention that perhaps aren't that obvious:

1. The only commit that's relevant for this PR is [this one](https://github.com/reduxjs/react-redux/pull/1273/commits/88dce648b9c3e7eeffbf0902345c4e43b49a54b6). The other one is the commit of #1272... I'm just being a bit optimistic and hoping that #1272 will get merged before this one.

2. My rationale for this change is the following:

- If the update comes as a result of the `forceRender` of `checkForUpdates`, then there is no need to re-evaluate the selector.

- If the update comes from "the outside", then it could be that:

1. The selector has been updated, in which case we need to re-evaluate the selector
2. It's a parent update that has nothing to do with us, so we don't need to re-evaluate the selector... What's likely, though, is that if the parent update was a result of the state changing, then `checkForUpdates` will already pick that change and trigger a render... Chances are that the child-update will have happened before the parent one, but it doesn't really matter, because it will happen during the same loop, so it will be batched... :slightly_smiling_face: 