### PR TITLE
Pass through props.context to connected component

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -160,8 +160,8 @@ export default function connectAdvanced(
         // Distinguish between actual "data" props that were passed to the wrapper component,
         // and values needed to control behavior (forwarded refs, alternate context instances).
         // To maintain the wrapperProps object reference, memoize this destructuring.
-        const { context, forwardedRef, ...wrapperProps } = props
-        return [context, forwardedRef, wrapperProps]
+        const { forwardedRef, ...wrapperProps } = props
+        return [props.context, forwardedRef, wrapperProps]
       }, [props])
 
       const ContextToUse = useMemo(() => {


### PR DESCRIPTION
This issue came up when I tried to update [connected-react-router](https://github.com/supasate/connected-react-router) to work with react-redux@7 (see https://github.com/supasate/connected-react-router/pull/303).

In react-redux@6, you were able to do the following:
```jsx
const myContext = React.createContext(null);

function MyComponent(props) {
  assert(props.context === myContext); // true
}
const ConnectedMyComponent = connect()(MyComponent);

// ...

<ConnectedMyComponent context={myContext} />
```

With react-redux@7, the context prop is no longer passed through to MyComponent. This PR "fixes" that. However, I'm really not an expert when it comes to React's context API and its usage in react-redux and connected-react-router. Let me know if this fix makes sense :)