### PR TITLE
Support server rendering with window polyfill

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -38,7 +38,11 @@ const initStateUpdates = () => [null, 0]
 // `connect` to perform sync updates to a ref to save the latest props after
 // a render is actually committed to the DOM.
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
+    ? useLayoutEffect
+    : useEffect
 
 export default function connectAdvanced(
   /*


### PR DESCRIPTION
React warns about using useLayoutEffect during server rendering if window has been polyfilled since only the existence of window is checked in connectAdvanced.js

I suggest using the same check that React has in [ExecutionEnvironment.js](https://github.com/facebook/react/blob/master/packages/shared/ExecutionEnvironment.js).

