### PR TITLE
Replace shallowEqual with reference equality in useSelector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5010,8 +5010,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -14,6 +14,8 @@ import Subscription from '../utils/Subscription'
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
+const refEquality = (a, b) => a === b
+
 /**
  * A hook to access the redux store's state. This hook takes a selector function
  * as an argument. The selector is called with the store state.
@@ -23,6 +25,7 @@ const useIsomorphicLayoutEffect =
  * useful if you provide a selector that memoizes values).
  *
  * @param {Function} selector the selector function
+ * @param {Function} equalityFn the function that will be used to determine equality
  *
  * @returns {any} the selected state
  *
@@ -37,7 +40,7 @@ const useIsomorphicLayoutEffect =
  *   return <div>{counter}</div>
  * }
  */
-export function useSelector(selector) {
+export function useSelector(selector, equalityFn = refEquality) {
   invariant(selector, `You must pass a selector to useSelectors`)
 
   const { store, subscription: contextSub } = useReduxContext()
@@ -82,7 +85,7 @@ export function useSelector(selector) {
       try {
         const newSelectedState = latestSelector.current(store.getState())
 
-        if (newSelectedState === latestSelectedState.current) {
+        if (equalityFn(newSelectedState, latestSelectedState.current)) {
           return
         }
 

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -1,7 +1,6 @@
 import { useReducer, useRef, useEffect, useMemo, useLayoutEffect } from 'react'
 import invariant from 'invariant'
 import { useReduxContext } from './useReduxContext'
-import shallowEqual from '../utils/shallowEqual'
 import Subscription from '../utils/Subscription'
 
 // React currently throws a warning when using useLayoutEffect on the server.
@@ -83,7 +82,7 @@ export function useSelector(selector) {
       try {
         const newSelectedState = latestSelector.current(store.getState())
 
-        if (shallowEqual(newSelectedState, latestSelectedState.current)) {
+        if (newSelectedState === latestSelectedState.current) {
           return
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { useStore } from './hooks/useStore'
 
 import { setBatch } from './utils/batch'
 import { unstable_batchedUpdates as batch } from './utils/reactBatchedUpdates'
+import shallowEqual from './utils/shallowEqual'
 
 setBatch(batch)
 
@@ -20,5 +21,6 @@ export {
   batch,
   useDispatch,
   useSelector,
-  useStore
+  useStore,
+  shallowEqual
 }

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -128,16 +128,12 @@ describe('React', () => {
       })
 
       describe('performance optimizations and bail-outs', () => {
-        it('should shallowly compare the selected state to prevent unnecessary updates', () => {
-          store = createStore(
-            ({ count, stable } = { count: -1, stable: {} }) => ({
-              count: count + 1,
-              stable
-            })
-          )
+        it('should compare the selected state by reference to prevent unnecessary updates', () => {
+          const state = {}
+          store = createStore(() => state)
 
           const Comp = () => {
-            const value = useSelector(s => Object.keys(s))
+            const value = useSelector(s => s)
             renderedItems.push(value)
             return <div />
           }


### PR DESCRIPTION
I thought I'd put this out there to get discussion going on this, before `7.1` final goes out, as I think this is a very important thing to iron out, and having a PR implementing the change will go a long way.

As discussed in https://github.com/reduxjs/react-redux/issues/1252#issuecomment-489266648, the argument for keeping `shallowEqual` seems to be that it is how `connect` currently works - well, as already stated in that thread, `useSelector` is not a replacement to `connect`, and the hooks API have already deviated from the familiar HOC API already, for example, dropping `useAction`.

I think that consumers of `useSelector` will be familiar with `useState` and will expect an API similar to that one - which deviated from `setState` in the same way that this PR deviates from `connect`. I think it will cause confusion for people when suddenly they see that their `const username = useSelector(getUsername)` hook causes rerenders they aren't expecting, and will have to scourge through the docs to find the very awkward looking workaround: `const { username } = useSelector(state => ({ username: getUsername(state) }))`.

Additionally, the use of `shallowEqual` here seems to be a case of early optimization which could possibly be introduced in the future if the need arises.