### PR TITLE
Add useShallowEqualSelector

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -20,10 +20,6 @@ const refEquality = (a, b) => a === b
  * A hook to access the redux store's state. This hook takes a selector function
  * as an argument. The selector is called with the store state.
  *
- * This hook takes a dependencies array as an optional second argument,
- * which when passed ensures referential stability of the selector (this is primarily
- * useful if you provide a selector that memoizes values).
- *
  * @param {Function} selector the selector function
  * @param {Function} equalityFn the function that will be used to determine equality
  *

--- a/src/hooks/useShallowEqualSelector.js
+++ b/src/hooks/useShallowEqualSelector.js
@@ -1,0 +1,26 @@
+import shallowEqual from '../utils/shallowEqual'
+import { useSelector } from './useSelector'
+
+/**
+ * A hook to access the redux store's state. This hook takes a selector function
+ * as an argument. The selector is called with the store state.
+ * It uses shallowEqual to determine whether to rerender
+ *
+ * @param {Function} selector the selector function
+ *
+ * @returns {any} the selected state
+ *
+ * @example
+ *
+ * import React from 'react'
+ * import { useSelector } from 'react-redux'
+ * import { RootState } from './store'
+ *
+ * export const CounterComponent = () => {
+ *   const counter = useSelector(state => ({ counter: selector.counter }))
+ *   return <div>{counter}</div>
+ * }
+ */
+export function useShallowEqualSelector(selector) {
+  return useSelector(selector, shallowEqual)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,11 @@ import connect from './connect/connect'
 
 import { useDispatch } from './hooks/useDispatch'
 import { useSelector } from './hooks/useSelector'
+import { useShallowEqualSelector } from './hooks/useShallowEqualSelector'
 import { useStore } from './hooks/useStore'
 
 import { setBatch } from './utils/batch'
 import { unstable_batchedUpdates as batch } from './utils/reactBatchedUpdates'
-import shallowEqual from './utils/shallowEqual'
 
 setBatch(batch)
 
@@ -22,5 +22,5 @@ export {
   useDispatch,
   useSelector,
   useStore,
-  shallowEqual
+  useShallowEqualSelector
 }

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -4,11 +4,8 @@ import React, { useCallback, useReducer } from 'react'
 import { createStore } from 'redux'
 import { renderHook, act } from 'react-hooks-testing-library'
 import * as rtl from 'react-testing-library'
-import {
-  Provider as ProviderMock,
-  useSelector,
-  shallowEqual
-} from '../../src/index.js'
+import { Provider as ProviderMock, useSelector } from '../../src/index.js'
+import shallowEqual from '../../src/utils/shallowEqual.js'
 import { useReduxContext } from '../../src/hooks/useReduxContext'
 
 describe('React', () => {

--- a/test/hooks/useShallowEqualSelector.spec.js
+++ b/test/hooks/useShallowEqualSelector.spec.js
@@ -1,0 +1,73 @@
+/*eslint-disable react/prop-types*/
+
+import React from 'react'
+import { createStore } from 'redux'
+import * as rtl from 'react-testing-library'
+import {
+  Provider as ProviderMock,
+  useShallowEqualSelector
+} from '../../src/index.js'
+
+describe('React', () => {
+  describe('hooks', () => {
+    describe('useShallowEqualSelector', () => {
+      let store
+      let renderedItems = []
+
+      beforeEach(() => {
+        store = createStore(({ count } = { count: -1 }) => ({
+          count: count + 1
+        }))
+        renderedItems = []
+      })
+
+      afterEach(() => rtl.cleanup())
+
+      describe('performance optimizations and bail-outs', () => {
+        it('allows shallow equal to prevent unnecessary updates', () => {
+          store = createStore(() => ({ foo: 'bar' }))
+
+          const Comp = () => {
+            const value = useShallowEqualSelector(s => s)
+            renderedItems.push(value)
+            return <div />
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          expect(renderedItems.length).toBe(1)
+
+          store.dispatch({ type: '' })
+
+          expect(renderedItems.length).toBe(1)
+        })
+
+        it('should rerender when shallowEqual returns false', () => {
+          store = createStore(() => ({ foo: {} }))
+
+          const Comp = () => {
+            const value = useShallowEqualSelector(s => s)
+            renderedItems.push(value)
+            return <div />
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          expect(renderedItems.length).toBe(1)
+
+          store.dispatch({ type: '' })
+
+          expect(renderedItems.length).toBe(2)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
The last PR exposed `shallowEqual`, with the intention of facilitating the implementation of a `useShallowEqualSelector`, using the new `equalFn` option of `useSelector`:

```js
const useShallowEqualSelector = selector => useSelector(selector, shallowEqual)
```

However, since this is already expanding the public API and there are no other current use-cases for `shallowEqual` to be used other than an argument to `useSelector`, I do not see why not go ahead and expose the new hook instead. The `equalFn` to `useSelector` remains there, if someone wants to provide their own custom one.