### PR TITLE
Update jsdocs for hooks

### DIFF
--- a/src/hooks/useDispatch.js
+++ b/src/hooks/useDispatch.js
@@ -5,7 +5,7 @@ import { useStore } from './useStore'
  * might want to use this hook it is recommended to use `useActions` instead to bind
  * action creators to the `dispatch` function.
  *
- * @returns {any} redux store's `dispatch` function
+ * @returns {any|function} redux store's `dispatch` function
  *
  * @example
  *

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -25,7 +25,7 @@ const refEquality = (a, b) => a === b
  * whether the component needs to be re-rendered.
  *
  * @param {Function} selector the selector function
- * @param {Function} equalityFn the function that will be used to determine equality
+ * @param {Function=} equalityFn the function that will be used to determine equality
  *
  * @returns {any} the selected state
  *


### PR DESCRIPTION
useSelector: Not having the second argument be optional in the jsdoc is making my IDE complain "Invalid number of arguments, expected 2"

useDispatch: My IDE sees this {any} return value and doesn't assume it can be called. I get "Method expression is not of function type". Suggesting it might be a function seems safe enough.