### PR TITLE
Fix link on docs

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -67,9 +67,9 @@ const mapStateToProps = (state, ownProps) => ({
 
 Your `mapStateToProps` functions are expected to return an object. This object, normally referred to as `stateProps`, will be merged as props to your connected component. If you define `mergeProps`, it will be supplied as the first parameter to `mergeProps`.
 
-The return of the `mapStateToProps` determine whether the connected component will re-render (details [here](../using-react-redux/connect-extracting-data-with-mapStateToProps.md#return-values-determine-if-your-component-re-renders)).
+The return of the `mapStateToProps` determine whether the connected component will re-render (details [here](../using-react-redux/connect-mapstate#return-values-determine-if-your-component-re-renders)).
 
-For more details on recommended usage of `mapStateToProps`, please refer to [our guide on using `mapStateToProps`](../using-react-redux/connect-extracting-data-with-mapStateToProps.md).
+For more details on recommended usage of `mapStateToProps`, please refer to [our guide on using `mapStateToProps`](../using-react-redux/connect-mapstate).
 
 > You may define `mapStateToProps` and `mapDispatchToProps` as a factory function, i.e., you return a function instead of an object. In this case your returned function will be treated as the real `mapStateToProps` or `mapDispatchToProps`, and be called in subsequent calls. You may see notes on [Factory Functions](#factory-functions) or our guide on performance optimizations.
 
@@ -151,7 +151,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 }
 ```
 
-For more details on recommended usage, please refer to [our guide on using `mapDispatchToProps`](../using-react-redux/connect-extracting-data-with-mapStateToProps.md).
+For more details on recommended usage, please refer to [our guide on using `mapDispatchToProps`](../using-react-redux/connect-mapdispatch).
 
 > You may define `mapStateToProps` and `mapDispatchToProps` as a factory function, i.e., you return a function instead of an object. In this case your returned function will be treated as the real `mapStateToProps` or `mapDispatchToProps`, and be called in subsequent calls. You may see notes on [Factory Functions](#factory-functions) or our guide on performance optimizations.
 
@@ -182,7 +182,7 @@ In this case, React-Redux binds the `dispatch` of your store to each of the acti
 bindActionCreators(mapDispatchToProps, dispatch)
 ```
 
-We also have a section in our `mapDispatchToProps` guide on the usage of object shorthand form [here](../using-react-redux/connect-extracting-data-with-mapStateToProps.md#defining-mapdispatchtoprops-as-an-object).
+We also have a section in our `mapDispatchToProps` guide on the usage of object shorthand form [here](../using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object).
 
 ### `mergeProps?: (stateProps, dispatchProps, ownProps) => Object`
 

--- a/website/versioned_docs/version-7.1/api/connect.md
+++ b/website/versioned_docs/version-7.1/api/connect.md
@@ -68,9 +68,9 @@ const mapStateToProps = (state, ownProps) => ({
 
 Your `mapStateToProps` functions are expected to return an object. This object, normally referred to as `stateProps`, will be merged as props to your connected component. If you define `mergeProps`, it will be supplied as the first parameter to `mergeProps`.
 
-The return of the `mapStateToProps` determine whether the connected component will re-render (details [here](../using-react-redux/connect-extracting-data-with-mapStateToProps.md#return-values-determine-if-your-component-re-renders)).
+The return of the `mapStateToProps` determine whether the connected component will re-render (details [here](../using-react-redux/connect-mapstate#return-values-determine-if-your-component-re-renders)).
 
-For more details on recommended usage of `mapStateToProps`, please refer to [our guide on using `mapStateToProps`](../using-react-redux/connect-extracting-data-with-mapStateToProps.md).
+For more details on recommended usage of `mapStateToProps`, please refer to [our guide on using `mapStateToProps`](../using-react-redux/connect-mapstate).
 
 > You may define `mapStateToProps` and `mapDispatchToProps` as a factory function, i.e., you return a function instead of an object. In this case your returned function will be treated as the real `mapStateToProps` or `mapDispatchToProps`, and be called in subsequent calls. You may see notes on [Factory Functions](#factory-functions) or our guide on performance optimizations.
 
@@ -152,7 +152,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 }
 ```
 
-For more details on recommended usage, please refer to [our guide on using `mapDispatchToProps`](../using-react-redux/connect-extracting-data-with-mapStateToProps.md).
+For more details on recommended usage, please refer to [our guide on using `mapDispatchToProps`](../using-react-redux/connect-mapdispatch).
 
 > You may define `mapStateToProps` and `mapDispatchToProps` as a factory function, i.e., you return a function instead of an object. In this case your returned function will be treated as the real `mapStateToProps` or `mapDispatchToProps`, and be called in subsequent calls. You may see notes on [Factory Functions](#factory-functions) or our guide on performance optimizations.
 
@@ -183,7 +183,7 @@ In this case, React-Redux binds the `dispatch` of your store to each of the acti
 bindActionCreators(mapDispatchToProps, dispatch)
 ```
 
-We also have a section in our `mapDispatchToProps` guide on the usage of object shorthand form [here](../using-react-redux/connect-extracting-data-with-mapStateToProps.md#defining-mapdispatchtoprops-as-an-object).
+We also have a section in our `mapDispatchToProps` guide on the usage of object shorthand form [here](../using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object).
 
 ### `mergeProps?: (stateProps, dispatchProps, ownProps) => Object`
 


### PR DESCRIPTION
Some of the links take you to the wrong url which does not exist. This PR fixes it hopefully.