### PR TITLE
Fix case when useSelector returns previous state (weird edge case?)

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -75,11 +75,9 @@ export function useSelector(selector, equalityFn = refEquality) {
     throw new Error(errorMessage)
   }
 
-  useIsomorphicLayoutEffect(() => {
-    latestSelector.current = selector
-    latestSelectedState.current = selectedState
-    latestSubscriptionCallbackError.current = undefined
-  })
+  latestSelector.current = selector
+  latestSelectedState.current = selectedState
+  latestSubscriptionCallbackError.current = undefined
 
   useIsomorphicLayoutEffect(() => {
     function checkForUpdates() {


### PR DESCRIPTION
Hi all, I'm experimenting with adding support for hooks to [kea](https://kea.js.org) (to the unreleased 1.0). Thanks to the new hooks in react-redux `7.1.0` this has been a blast! Thank you for all the hard work in making that a reality!

However, I might have stumbled upon a weird edge case, which I can only reproduce in the test suite for `kea` and nowhere else. I think I'm not doing anything wrong myself, but that will always remain a possibility. I tried cloning `react-redux` and replicating the situation inside a broken test here, but it would always pass, no matter what I tried to do. So I'm not sure why this is happening.

In any case, [this](https://github.com/keajs/kea/blob/a39211743ec7ce0483dc2851dda342fa46aeb8bf/src/__tests__/hooks.js) is the test that fails. 

Inside it:
- I define 1 action (`updateName`), 1 reducer (`name`) and 2 custom selectors (`capitalizedName` and `upperCaseName`).
- Render a component that uses `useSelector` three times to get the values for `name`, `capitalizedName` and `upperCaseName` from the store
- `console.log` these 3 variables when the component renders for debugging
- Dispatch `updateName` a few times to change the values and assert that the rendered component displays the new values.

What happens: 
- The second time I dispatch a new `updateName` action with a unique name, the first selector retains the old value, the other two selectors return the new value:

```js
  store.dispatch(logic.actions.updateName('somename'))
  // console.log in render:
  //   { name: 'somename',
  //     capitalizedName: 'Somename',
  //     upperCaseName: 'SOMENAME' }

  store.dispatch(logic.actions.updateName('somename3'))
  // console.log in render:
  //   { name: 'somename',  // !!! should be 'somename3'
  //     capitalizedName: 'Somename3',
  //     upperCaseName: 'SOMENAME3' }
```

Some remarks:
- The code uses kea's `useProps` and `useActions`, but replacing them with raw `useSelector` calls and removing `useActions` makes no difference.
- All selectors are created via reselect, but when I selected from the store directly (`useSelector(state => state.x.name)`, etc), the bug remained.
- I'm using enzyme to test this, however when I changed it to `@testing-library/react` like react-redux uses, the bug remained.
- It's always the first selector that retains the old value. If I swap the order of selectors (e.g. putting `capitalizedName` first), whatever is the first one will retain the old value.

I tried my best to debug this and ended up [here](https://github.com/reduxjs/react-redux/blob/316467a07e29911d82ba0342364a907e05d9066c/src/hooks/useSelector.js#L80)

In the `checkForUpdates` function (inside the second `useIsomorphicLayoutEffect`), the [line](https://github.com/reduxjs/react-redux/blob/316467a07e29911d82ba0342364a907e05d9066c/src/hooks/useSelector.js#L93):

```js
latestSelectedState.current = newSelectedState
```

... sets the `latestSelectedState.current` to the value `"somename3"`, however then for some reason the first `useIsomorphicLayoutEffect` block is called after this and in there `latestSelectedState.current` is reverted to `selectedState`, which still contains the old value (`"somename"`)

```js
  useIsomorphicLayoutEffect(() => {
    latestSelector.current = selector
    latestSelectedState.current = selectedState
    latestSubscriptionCallbackError.current = undefined
  })
```

The `useSelector` hook itself is not run from the beginning, just react somehow thinks running these 3 lines above makes sense, after a subscription decides to call `forceRender({})`.

The easiest solution I've found to fix my issue is to just remove the `useIsomorphicLayoutEffect` block from around the 3 ref setters. All the `react-redux` tests pass after this.

However there must have been a reason why the code is written like this. It might break other things I'm not aware of, so please advise if this "fix" is actually a fix or not.

Cheers! 🍻 