### PR TITLE
Updates package versions in Quick Start docs

### DIFF
--- a/docs/introduction/quick-start.md
+++ b/docs/introduction/quick-start.md
@@ -11,7 +11,7 @@ sidebar_label: Quick Start
 
 ## Installation
 
-React Redux 6.x requires **React 16.4 or later.**
+React Redux 7.1 requires **React 16.8.3 or later.**
 
 To use React Redux with your React app:
 

--- a/website/versioned_docs/version-7.1/introduction/quick-start.md
+++ b/website/versioned_docs/version-7.1/introduction/quick-start.md
@@ -12,7 +12,7 @@ original_id: quick-start
 
 ## Installation
 
-React Redux 6.x requires **React 16.4 or later.**
+React Redux 7.1 requires **React 16.8.3 or later.**
 
 To use React Redux with your React app:
 


### PR DESCRIPTION
Hello!

I just noticed these versions being outdated in [the docs](https://react-redux.js.org/introduction/quick-start#installation) for `react-redux` v7.1. Same thing happens in [docs for v7.0](https://react-redux.js.org/7.0/introduction/quick-start#installation), however I am not sure how you handle maintenance of the docs for older versions of `react-redux`.