### PR TITLE
change react-dom from devDependency to dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7155,7 +7155,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
       "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -7740,7 +7739,6 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "invariant": "^2.2.4",
     "loose-envify": "^1.4.0",
     "prop-types": "^15.7.2",
+    "react-dom": "^16.8.6",
     "react-is": "^16.8.6"
   },
   "devDependencies": {
@@ -74,7 +75,6 @@
     "jest-dom": "^3.5.0",
     "prettier": "^1.18.2",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",
     "redux": "^4.0.1",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
Since #1209, we import `react-dom` explicitly, so maybe it should be put into `dependencies` instead of `devDependencies`.
Put it in `devDependencies` will confuse some plugins of build systems (e.g. Webpack), makes them think `react-dom` is not needed for `react-redux`.
