### PR TITLE
Fix add missing peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.3",
+    "react-dom": "^16.8.6",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
   },
   "dependencies": {


### PR DESCRIPTION
react-dom is used in production code, so it should be a peer dependency
https://github.com/reduxjs/react-redux/blob/fa5857281a37545c7c036fb2499159b865b1c57d/src/utils/reactBatchedUpdates.js#L2

It currently causes issues with pnpm which won't provide access to packages that
are not declared as dependencies in package.json