### PR TITLE
remove browserify config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,11 +85,6 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.0.0"
   },
-  "browserify": {
-    "transform": [
-      "loose-envify"
-    ]
-  },
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,


### PR DESCRIPTION
Since we use rollup now, we don't need any browserify config.