### PR TITLE
remove useless checkForUpdates()

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -92,8 +92,6 @@ function useSelectorWithStoreAndSubscription(
     subscription.onStateChange = checkForUpdates
     subscription.trySubscribe()
 
-    checkForUpdates()
-
     return () => subscription.tryUnsubscribe()
   }, [store, subscription])
 


### PR DESCRIPTION
## context

I start reading the react-redux source code tonight. I find here is a strange `checkForUpdates` call:

https://github.com/alsotang/react-redux/blob/5b268f3f07eaf054eca47bebfd0fcf1d8bcc96c4/src/hooks/useSelector.js#L95

I try to understand why it is here and figure out that perhaps the store would change before we subscribe it. And here is a test case to validate this situation:

https://github.com/alsotang/react-redux/blob/5b268f3f07eaf054eca47bebfd0fcf1d8bcc96c4/test/hooks/useSelector.spec.js#L135

## my exploration

I try to remove the `checkForUpdates` call and see what would happen. But all tests passed when I type `npm test`

And I put `console.log` in the first line of `checkForUpdates`. When I don't remove it, it logs twice. When I remove it, it logs once.

So I think manually call `checkForUpdates` when subscribe is a waste, but I don't know why.

## my thinking

1. Some mechanism changed, so manually call `checkForUpdates` is unnecessary.
2. We should add a specific test to ensure the call is not a waste.



