### PR TITLE
fix: List optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,17 @@
   },
   "peerDependencies": {
     "react": "^16.8.3",
+    "react-dom": "^16.8.3",
+    "react-native": "^0.18.0",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
`react-dom` is required from the main bundle (not really optional I suppose) while `react-native` is required when using it with `react-native` and their batched updates.

Additional context:
* [optional peer dependencies](https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md) (implemented in `yarn@1.13.0`, `npm@6.11.0` but not [yet](https://github.com/nodejs/node/pull/29273) bundled with node and `pnpm@?`

I'm currently not using this feature myself until node bundles `npm@6.11`.  Just creating this PR now so that we can discuss any concerns you have.