### PR TITLE
Add createActionsHook factory method.

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -212,8 +212,48 @@ export const App = () => {
 
 ## Removed: `useActions()`
 
+## `createActionsHook()`
 
+```js
+const useActions : Function = createActionsHook(actions : Object);
+```
 
+This hook factory can be used in with your action creators in order to expose a `useActions()` hook that can be used in your components.
+
+#### Example
+
+```jsx
+// actions.js
+import { createActionsHook } from 'react-redux'
+
+export const doSomething = e => ({  
+  type: 'admin-button-action',
+  payload: e.target.value,
+})
+
+export const useActions = createActionsHook({ doSomething })
+
+// AdminButton.jsx
+import { useSelector } from 'react-redux'
+import { useActions } from './actions'
+ 
+export const AdminButton = ({ key, text }) => {
+  const user = useSelector(({ user }) => user)
+  const action = useActions([ key, user ])
+  if (!user.isAdmin) return null
+  return (
+    <button
+      class="admin-button"
+      onClick={action.doSomething}
+      value={id}
+    >
+      {text}
+    </button>
+  )
+}
+```
+
+When passing an array of dependencies to `useActions` the bound actions are memoized.
 
 
 ## `useDispatch()`

--- a/src/hooks/createActionsHook.js
+++ b/src/hooks/createActionsHook.js
@@ -1,0 +1,48 @@
+import { useMemo } from 'react'
+import { bindActionCreators } from 'redux'
+import { useDispatch } from './useDispatch'
+
+/**
+ * Hook factory, which creates a `useActions` hook bound to dispatch.
+ * 
+ * @param {Object} actions object to bind to dispatch.
+ * @returns {Function} A `useActions` hook bound to dispatch.
+ *  
+ * @example
+ * // actions.js
+ * import { bindActionCreators } from 'react-redux'
+ * 
+ * export const doSomething = e => ({  
+ *   type: 'sometype',
+ *   e.target.value,
+ * })
+ * 
+ * export const useActions = createActionsHook({ doSomething })
+ * 
+ * // component.js
+ * import React from 'react'
+ * import { useSelector } from 'react-redux'
+ * import { useActions } from './actions'
+ * 
+ * export const AdminButton = ({ key, text }) => {
+ *   const user = useSelector(({ user }) => user)
+ *   const action = useActions([ key, user ])
+ *   if (!user.isAdmin) return null
+ *   return (
+ *     <button value={id} onClick={action.doSomething}>
+ *       {text}
+ *     </button>
+ *   )
+ * }
+ */
+export function createActionsHook(actions) {
+  return function useActions(deps) {
+    const dispatch = useDispatch();
+    return useMemo(() => {
+      if (Array.isArray(actions)) {
+        return actions.map(a => bindActionCreators(a, dispatch))
+      }
+      return bindActionCreators(actions, dispatch)
+    }, deps ? [dispatch, ...deps] : [dispatch])
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import connect from './connect/connect'
 import { useDispatch, createDispatchHook } from './hooks/useDispatch'
 import { useSelector, createSelectorHook } from './hooks/useSelector'
 import { useStore, createStoreHook } from './hooks/useStore'
+import { createActionsHook } from './hooks/createActionsHook'
 
 import { setBatch } from './utils/batch'
 import { unstable_batchedUpdates as batch } from './utils/reactBatchedUpdates'
@@ -25,5 +26,6 @@ export {
   createSelectorHook,
   useStore,
   createStoreHook,
+  createActionsHook,
   shallowEqual
 }


### PR DESCRIPTION
I know the `useActions` method was removed for various reasons.  However, this factory method would be incredibly useful for `actions` modules created by developers using `react-redux` in their own applications.

This `createActionsHook` will allow developers to easily expose a `useActions` export from their own actions modules.