### PR TITLE
Fix React version check to support 16.10

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { storeShape, subscriptionShape } from '../utils/PropTypes'
 import warning from '../utils/warning'
 
-const prefixUnsafeLifecycleMethods = parseFloat(React.version) >= 16.3
+const prefixUnsafeLifecycleMethods = typeof React.forwardRef !== "undefined"
 
 let didWarnAboutReceivingStore = false
 function warnAboutReceivingStore() {

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -6,7 +6,7 @@ import { isValidElementType } from 'react-is'
 import Subscription from '../utils/Subscription'
 import { storeShape, subscriptionShape } from '../utils/PropTypes'
 
-const prefixUnsafeLifecycleMethods = parseFloat(React.version) >= 16.3
+const prefixUnsafeLifecycleMethods = typeof React.forwardRef !== "undefined"
 
 let hotReloadingVersion = 0
 const dummyState = {}


### PR DESCRIPTION
Since `parseFloat(React.version)` resolves to `16.1`, that breaks our version check. So, I've switched to checking against the `forwardRef` API's existence, which was also added in 16.3.