### PR TITLE
 Avoid warnings in React >=16.3

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -267,8 +267,8 @@ export default function connectAdvanced(
 
     if (prefixUnsafeLifecycleMethods) {
       // Use UNSAFE_ event name where supported
-      Connect.UNSAFE_componentWillReceiveProps = Connect.componentWillReceiveProps
-      delete Connect.componentWillReceiveProps
+      Connect.prototype.UNSAFE_componentWillReceiveProps = Connect.prototype.componentWillReceiveProps
+      delete Connect.prototype.componentWillReceiveProps
     }
 
     /* eslint-enable react/no-deprecated */
@@ -280,7 +280,9 @@ export default function connectAdvanced(
     Connect.propTypes = contextTypes
 
     if (process.env.NODE_ENV !== 'production') {
-      Connect.prototype.componentWillUpdate = function componentWillUpdate() {
+      // Use UNSAFE_ event name where supported
+      const eventName = prefixUnsafeLifecycleMethods ? 'UNSAFE_componentWillUpdate' : 'componentWillUpdate';
+      Connect.prototype[eventName] = function componentWillUpdate() {
         // We are hot reloading!
         if (this.version !== version) {
           this.version = version


### PR DESCRIPTION
Following up on #1407, there are two issues still causing warnings on the 5.x branch:

* In development, componentWillUpdate is used. Even though this is dev-only, it causes verbose warnings that can mask other issues when working in a large project.
* componentWillReceiveProps is incorrectly deleted from Connect's static properties, not from the prototype, so the delete is actually a no-op.

This PR addresses both issues. Thanks!

(This fixes an issue in an earlier PR I opened (#1409) -- I had gotten the lifecycle method wrong)