### PR TITLE
Don't change reference returned by useSelector if equality Fn passes

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -49,6 +49,9 @@ function useSelectorWithStoreAndSubscription(
       latestSubscriptionCallbackError.current
     ) {
       selectedState = selector(store.getState())
+      if (equalityFn(selectedState, latestSelectedState.current)) {
+        selectedState = latestSelectedState.current;
+      }
     } else {
       selectedState = latestSelectedState.current
     }

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -50,7 +50,7 @@ function useSelectorWithStoreAndSubscription(
     ) {
       selectedState = selector(store.getState())
       if (equalityFn(selectedState, latestSelectedState.current)) {
-        selectedState = latestSelectedState.current;
+        selectedState = latestSelectedState.current
       }
     } else {
       selectedState = latestSelectedState.current


### PR DESCRIPTION
Don't change the reference returned by useSelector if equality fn passes

Why? (Performance)
Many developers inline their selector functions. The current implementation makes it so that even if they implement the equalityFn to always return true the reference returned by the selector will change because the selector reference changed. This can cause components receiving these objects to re-render if their props aren't primitives! 

To get around this I created a version of useSelector that uses a selector reference that won't change eg:
```
export const useSelectorPerformant = <T, V>(
  selector: (state: T) => V,
  comparator?: (a: V, b: V) => boolean,
): V => {
    const selectorRef = useUpdatingRef(selector);
    const fixedSelector = useRef((rootState: T) => {
      return selectorRef.current(rootState);
    })
    return useSelector<T, V>(fixedSelector.current, comparator);
}

export const useConstantSelectorPerformant = <T, V>(
  selector: (state: T) => V,
  comparator?: (a: V, b: V) => boolean,
): V => {
    const selectorRef = useRef(selector);
    const fixedSelector = useRef((rootState: T) => {
      return selectorRef.current(rootState);
    })
    return useSelector<T, V>(fixedSelector.current, comparator);
}
````

However, Ideally Redux can just run the equalityFn to check if the reference should change.

For reference I tested this behavior by checking if the reference returned by the following selector is changing and in the current implementation it is.
```
  const obj = useSelector(() => ({ someKey: [{id: 1, name: 'test'}] }, () => true)
```