### PR TITLE
Docs: Fix Code Example for API `connect()`

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -581,7 +581,7 @@ function mapStateToProps(state) {
 
 const mapStateToProps = (state, ownProps = {}) => {
   console.log(state) // state
-  console.log(ownProps) // {}
+  console.log(ownProps) // undefined
 }
 ```
 


### PR DESCRIPTION
The docs: [Using React Redux > Connect: Extracting Data with mapStateToProps](https://react-redux.js.org/next/using-react-redux/connect-mapstate#the-number-of-declared-arguments-affects-behavior)

Specify the following behavior in the code example:
```js
function mapStateToProps(state) {
  console.log(state) // state
  console.log(arguments[1]) // undefined
}
const mapStateToProps = (state, ownProps = {}) => {
  console.log(state) // state
  console.log(ownProps) // undefined
}
```


These docs for `connect()` show a code example that is not consistent with above example, nor the explanation: [API Reference > connect()](https://react-redux.js.org/next/api/connect#the-arity-of-maptoprops-functions)

> `ownProps` **is not passed** to `mapStateToProps` and `mapDispatchToProps` if the formal definition of the function contains one mandatory parameter (function has length 1). For example, **functions defined like below won't receive `ownProps` as the second argument**