### PR TITLE
Docs: Fix Code Example for Arity of `mapStateToProps`

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -571,7 +571,7 @@ export default connect(
 
 The number of declared function parameters of `mapStateToProps` and `mapDispatchToProps` determines whether they receive `ownProps`
 
-> Note: `ownProps` is not passed to `mapStateToProps` and `mapDispatchToProps` if the formal definition of the function contains one mandatory parameter (function has length 1). For example, functions defined like below won't receive `ownProps` as the second argument
+> Note: `ownProps` is not passed to `mapStateToProps` and `mapDispatchToProps` if the formal definition of the function contains one mandatory parameter (function has length 1). For example, functions defined like below won't receive `ownProps` as the second argument. If the incoming value of `ownProps` is `undefined`, the default argument value will be  used.
 
 ```js
 function mapStateToProps(state) {

--- a/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
+++ b/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
@@ -184,7 +184,7 @@ function mapStateToProps(state) {
 }
 const mapStateToProps = (state, ownProps = {}) => {
   console.log(state) // state
-  console.log(ownProps) // undefined
+  console.log(ownProps) // {}
 }
 ```
 


### PR DESCRIPTION
Related: #1413

Makes the code example for `mapStateToProps` consistent with [Using React Redux > Connect: Extracting Data with mapStateToProps](https://react-redux.js.org/next/using-react-redux/connect-mapstate#the-number-of-declared-arguments-affects-behavior).

If the incoming value of `ownProps` is undefined, the default argument value will be used.