### PR TITLE
import createContext as named import

### DIFF
--- a/src/components/Context.js
+++ b/src/components/Context.js
@@ -1,5 +1,5 @@
-import React from 'react'
+import { createContext } from 'react'
 
-export const ReactReduxContext = React.createContext(null)
+export const ReactReduxContext = createContext(null)
 
 export default ReactReduxContext


### PR DESCRIPTION
By switching to a named import would help with the tree-shake, and also authors could use `react-redux` without the need to export a default `React` as part of the compatibility layer. The functionality does not change.

For example, in the case of `preact-redux` the compatibility layer for bridging `react-redux` with `preact` would not have to use the default export for React, at all. That would result in a better tree-shake result and smaller bundlesize.

Looking forward!