### PR TITLE
Use the same condition for checking if SSR in useSelector.js as in connectAdvanced.js

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -20,7 +20,11 @@ import { ReactReduxContext } from '../components/Context'
 // is created synchronously, otherwise a store update may occur before the
 // subscription is created and an inconsistent state may be observed
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
+    ? useLayoutEffect
+    : useEffect
 
 const refEquality = (a, b) => a === b
 


### PR DESCRIPTION
In connectAdvanced.js, window.document.createElement is checked to determine whether the code is running server side. In useSelector only window !== undefined is checked.

Many projects polyfill window on the server, which causes the useLayoutEffect warning when using useSelector. Changing to the more specific condition fixes this.