### PR TITLE
Add DEV Community link to Community Resources

### DIFF
--- a/website/versioned_docs/version-7.1/introduction/why-use-react-redux.md
+++ b/website/versioned_docs/version-7.1/introduction/why-use-react-redux.md
@@ -89,3 +89,4 @@ As the official binding library for React and Redux, React Redux has a large com
 - Reddit: [/r/reactjs](https://www.reddit.com/r/reactjs/), [/r/reduxjs](https://www.reddit.com/r/reduxjs/)
 - Github issues (bug reports and feature requests): https://github.com/reduxjs/react-redux/issues
 - Tutorials, articles, and further resources: [React/Redux Links](https://github.com/markerikson/react-redux-links)
+- DEV Community: [DEV's Redux tag](https://dev.to/t/redux)


### PR DESCRIPTION
Added a link to [DEV Community] (https://dev.to/) to show that we are part of a large community 🖖