### PR TITLE
Adds react-dom and react-native as optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,16 @@
   },
   "peerDependencies": {
     "react": "^16.8.3",
+    "react-dom": "^16.8.3",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
This diff adds `react-dom` and `react-native` as **optional** peer dependencies.

The `react-redux` package currently published doesn't list them, which is invalid. For example, here's what Yarn v2 is throwing:

![image](https://user-images.githubusercontent.com/1037931/66759680-ff7beb00-eea0-11e9-894b-6e7322d093a5.png)

Optional peer dependencies are supported by all three package managers and will silence warning that would otherwise appear if a consumer was omitting them.