### PR TITLE
Remove unused `latestStoreState` field

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -244,7 +244,7 @@ export default function connectAdvanced(
       // We need to force this wrapper component to re-render whenever a Redux store update
       // causes a change to the calculated child component props (or we caught an error in mapState)
       const [
-        [previousStateUpdateResult],
+        [previousStateUpdateResult, updateCount],
         forceComponentUpdateDispatch
       ] = useReducer(storeStateUpdatesReducer, EMPTY_ARRAY, initStateUpdates)
 
@@ -350,7 +350,6 @@ export default function connectAdvanced(
             forceComponentUpdateDispatch({
               type: 'STORE_UPDATED',
               payload: {
-                latestStoreState,
                 error
               }
             })

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -244,7 +244,7 @@ export default function connectAdvanced(
       // We need to force this wrapper component to re-render whenever a Redux store update
       // causes a change to the calculated child component props (or we caught an error in mapState)
       const [
-        [previousStateUpdateResult, updateCount],
+        [previousStateUpdateResult],
         forceComponentUpdateDispatch
       ] = useReducer(storeStateUpdatesReducer, EMPTY_ARRAY, initStateUpdates)
 


### PR DESCRIPTION
1. This field doesn't actually affect anything: `action.payload` is always a fresh object anyway
2. Holding a reference to some arbitrary state from the past (namely, the one that triggered the last update for given component) leads to huge memory leaks if the state object is large and there are lots of connected components.