### PR TITLE
Fix spelling in hooks error message

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -57,7 +57,7 @@ function useSelectorWithStoreAndSubscription(
       selectedState = latestSelectedState.current
     }
   } catch (err) {
-    let errorMessage = `An error occured while selecting the store state: ${err.message}.`
+    let errorMessage = `An error occurred while selecting the store state: ${err.message}.`
 
     if (latestSubscriptionCallbackError.current) {
       errorMessage += `\nThe error may be correlated with this previous error:\n${latestSubscriptionCallbackError.current.stack}\n\nOriginal stack trace:`


### PR DESCRIPTION
I was writing some tests for a hook that throws inside of a selector and I ran into this little suggestion via my code spell checker:

![image](https://user-images.githubusercontent.com/10551026/66774520-bec7a600-ee8f-11e9-9417-cc61e73d4504.png)

So here we are! 😅