### PR TITLE
fix performance createListenerCollection

### DIFF
--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -7,18 +7,16 @@ import { getBatch } from './batch'
 const nullListeners = { notify() {} }
 
 function createListenerCollection() {
-  var batch = getBatch()
-  // the current/next pattern is copied from redux's createStore code.
-  // TODO: refactor+expose that code to be reusable here?
+  const batch = getBatch()
+  let listeners = {}
+  let id = 0
 
-  var current = {}
-  var id = 0
   return {
     clear() {
-      current = {}
+      listeners = {}
     },
+
     notify() {
-      var listeners = current
       batch(() => {
         for (const id in listeners) {
           listeners[id]()
@@ -27,14 +25,15 @@ function createListenerCollection() {
     },
 
     get() {
-      return current
+      return listeners
     },
 
     subscribe(listener) {
-      var currentId = id++
-      current[currentId] = listener
+      const currentId = id++
+      listeners[currentId] = listener
+
       return function unsubscribe() {
-        delete current[currentId]
+        delete listeners[currentId]
       }
     }
   }

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -7,18 +7,19 @@ import { getBatch } from './batch'
 const nullListeners = { notify() {} }
 
 function createListenerCollection() {
-  var batch = getBatch() // the current/next pattern is copied from redux's createStore code.
+  var batch = getBatch()
+  // the current/next pattern is copied from redux's createStore code.
   // TODO: refactor+expose that code to be reusable here?
 
   var current = {}
   var id = 0
   return {
-    clear: function clear() {
+    clear() {
       current = {}
     },
-    notify: function notify() {
+    notify() {
       var listeners = current
-      batch(function() {
+      batch(() => {
         for (const id in listeners) {
           listeners[id]()
         }
@@ -29,7 +30,7 @@ function createListenerCollection() {
       return current
     },
 
-    subscribe: function subscribe(listener) {
+    subscribe(listener) {
       var currentId = id++
       current[currentId] = listener
       return function unsubscribe() {

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -4,46 +4,31 @@ import { getBatch } from './batch'
 // well as nesting subscriptions of descendant components, so that we can ensure the
 // ancestor components re-render before descendants
 
-const CLEARED = null
 const nullListeners = { notify() {} }
 
 function createListenerCollection() {
-  const batch = getBatch()
-  // the current/next pattern is copied from redux's createStore code.
+  var batch = getBatch() // the current/next pattern is copied from redux's createStore code.
   // TODO: refactor+expose that code to be reusable here?
-  let current = []
-  let next = []
 
+  var current = {}
+  var id = 0
   return {
-    clear() {
-      next = CLEARED
-      current = CLEARED
+    clear: function clear() {
+      current = {}
     },
-
-    notify() {
-      const listeners = (current = next)
-      batch(() => {
-        for (let i = 0; i < listeners.length; i++) {
-          listeners[i]()
+    notify: function notify() {
+      var listeners = current
+      batch(function() {
+        for (const id in listeners) {
+          listeners[id]()
         }
       })
     },
-
-    get() {
-      return next
-    },
-
-    subscribe(listener) {
-      let isSubscribed = true
-      if (next === current) next = current.slice()
-      next.push(listener)
-
+    subscribe: function subscribe(listener) {
+      var currentId = id++
+      current[currentId] = listener
       return function unsubscribe() {
-        if (!isSubscribed || current === CLEARED) return
-        isSubscribed = false
-
-        if (next === current) next = current.slice()
-        next.splice(next.indexOf(listener), 1)
+        delete current[currentId]
       }
     }
   }

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -24,6 +24,11 @@ function createListenerCollection() {
         }
       })
     },
+
+    get() {
+      return current
+    },
+
     subscribe: function subscribe(listener) {
       var currentId = id++
       current[currentId] = listener

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -97,11 +97,11 @@ describe('React', () => {
             </ProviderMock>
           )
 
-          expect(rootSubscription.listeners.get().length).toBe(1)
+          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(1)
 
           store.dispatch({ type: '' })
 
-          expect(rootSubscription.listeners.get().length).toBe(2)
+          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(2)
         })
 
         it('unsubscribes when the component is unmounted', () => {
@@ -125,11 +125,11 @@ describe('React', () => {
             </ProviderMock>
           )
 
-          expect(rootSubscription.listeners.get().length).toBe(2)
+          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(2)
 
           store.dispatch({ type: '' })
 
-          expect(rootSubscription.listeners.get().length).toBe(1)
+          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(1)
         })
 
         it('notices store updates between render and store subscription effect', () => {


### PR DESCRIPTION
createListenerCollection has a bad performance for more listeners.
In my implementation, performance is much better

before: 
<img width="1914" alt="Screen Shot 2019-11-06 at 18 13 44" src="https://user-images.githubusercontent.com/13157694/68310694-7cc20680-00c1-11ea-9083-dd8b0525c02b.png">

after:
<img width="957" alt="Screen Shot 2019-11-06 at 18 18 26" src="https://user-images.githubusercontent.com/13157694/68310923-de827080-00c1-11ea-9a31-b830e2040afa.png">

