### PR TITLE
Revert "fix performance createListenerCollection (#1450)"

### DIFF
--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -97,11 +97,11 @@ describe('React', () => {
             </ProviderMock>
           )
 
-          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(1)
+          expect(rootSubscription.listeners.get().length).toBe(1)
 
           store.dispatch({ type: '' })
 
-          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(2)
+          expect(rootSubscription.listeners.get().length).toBe(2)
         })
 
         it('unsubscribes when the component is unmounted', () => {
@@ -125,11 +125,11 @@ describe('React', () => {
             </ProviderMock>
           )
 
-          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(2)
+          expect(rootSubscription.listeners.get().length).toBe(2)
 
           store.dispatch({ type: '' })
 
-          expect(Object.keys(rootSubscription.listeners.get()).length).toBe(1)
+          expect(rootSubscription.listeners.get().length).toBe(1)
         })
 
         it('notices store updates between render and store subscription effect', () => {


### PR DESCRIPTION
This reverts commit 476c0de5d20acd45fbcea09fe7e52304184cc274.

https://github.com/reduxjs/react-redux/pull/1450 There is no guarantee on the order of calling parent/child selectors.