### PR TITLE
Remove invariant in favor of doing NODE_ENV checks directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6250,6 +6250,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "hoist-non-react-statics": "^3.3.0",
-    "invariant": "^2.2.4",
     "loose-envify": "^1.4.0",
     "prop-types": "^15.7.2",
     "react-is": "^16.9.0"

--- a/src/hooks/useReduxContext.js
+++ b/src/hooks/useReduxContext.js
@@ -1,5 +1,4 @@
 import { useContext } from 'react'
-import invariant from 'invariant'
 import { ReactReduxContext } from '../components/Context'
 
 /**
@@ -21,10 +20,11 @@ import { ReactReduxContext } from '../components/Context'
 export function useReduxContext() {
   const contextValue = useContext(ReactReduxContext)
 
-  invariant(
-    contextValue,
-    'could not find react-redux context value; please ensure the component is wrapped in a <Provider>'
-  )
+  if (process.env.NODE_ENV !== 'production' && !contextValue) {
+    throw new Error(
+      'could not find react-redux context value; please ensure the component is wrapped in a <Provider>'
+    )
+  }
 
   return contextValue
 }

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -1,5 +1,4 @@
 import { useReducer, useRef, useMemo, useContext } from 'react'
-import invariant from 'invariant'
 import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
 import Subscription from '../utils/Subscription'
 import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
@@ -95,8 +94,9 @@ export function createSelectorHook(context = ReactReduxContext) {
       ? useDefaultReduxContext
       : () => useContext(context)
   return function useSelector(selector, equalityFn = refEquality) {
-    invariant(selector, `You must pass a selector to useSelectors`)
-
+    if (process.env.NODE_ENV !== 'production' && !selector) {
+      throw new Error(`You must pass a selector to useSelectors`)
+    }
     const { store, subscription: contextSub } = useReduxContext()
 
     return useSelectorWithStoreAndSubscription(


### PR DESCRIPTION
Relates to https://github.com/reduxjs/react-redux/issues/1470

Removes tiny (but distributes solely in CJS format and thus deoptimizing) dependency. It also follows suit of https://github.com/facebook/react/issues/16753 - this should be more approachable to newcomers, because `invariant` is a little bit quirky - in example I often found myself wondering if I should use passing or failing condition when working with various OSS projects using this pattern. This change makes it easier to immediately know how this works.

This only helps webpack as Rollup is smart enough to remove this dependency on its own. Results on my playground:
```diff

Rolluped:
    3330
Rolluped & uglified:
    2388
Webpacked:
-   3294
+   3071

```