### PR TITLE
Pass @babel/runtime version to @babel/plugin-transform-runtime

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,6 +9,14 @@ module.exports = {
     ['@babel/proposal-object-rest-spread', { loose }],
     '@babel/transform-react-jsx',
     cjs && ['@babel/transform-modules-commonjs', { loose }],
-    ['@babel/transform-runtime', { useESModules: !cjs }],
-  ].filter(Boolean),
+    [
+      '@babel/transform-runtime',
+      {
+        useESModules: !cjs,
+        version: require('./package.json').dependencies[
+          '@babel/runtime'
+        ].replace(/^[^0-9]*/, '')
+      }
+    ]
+  ].filter(Boolean)
 }


### PR DESCRIPTION
It doesn't change anything right now, but it's a future-proof change that will allow `@babel/plugin-transform-runtime` to add imports to `@babel/runtime` helpers based on currently used version of `@babel/runtime` package - instead of falling back to list of helpers available in initial Babel 7 release.