### PR TITLE
Rethrowing original errors thrown in selector functions

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -35,14 +35,11 @@ function useSelectorWithStoreAndSubscription(
       selectedState = latestSelectedState.current
     }
   } catch (err) {
-    let errorMessage = `An error occurred while selecting the store state: `
-    errorMessage += err.stack ? `\n${err.stack}\n` : err.message
-
     if (latestSubscriptionCallbackError.current) {
-      errorMessage += `\nThe error may be correlated with this previous error:\n${latestSubscriptionCallbackError.current.stack}\n\nOriginal stack trace:`
+      err.message += `\nThe error may be correlated with this previous error:\n${latestSubscriptionCallbackError.current.stack}\n\n`
     }
 
-    throw new Error(errorMessage)
+    throw err
   }
 
   useIsomorphicLayoutEffect(() => {

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -35,7 +35,8 @@ function useSelectorWithStoreAndSubscription(
       selectedState = latestSelectedState.current
     }
   } catch (err) {
-    let errorMessage = `An error occurred while selecting the store state: ${err.message}.`
+    let errorMessage = `An error occurred while selecting the store state: `
+    errorMessage += err.stack ? `\n${err.stack}\n` : err.message
 
     if (latestSubscriptionCallbackError.current) {
       errorMessage += `\nThe error may be correlated with this previous error:\n${latestSubscriptionCallbackError.current.stack}\n\nOriginal stack trace:`


### PR DESCRIPTION
When throwing error from selector function, append original error stacktrace (if present) to new error. Should fix #1433 