### PR TITLE
Docs: fix code example in static-types.md

### DIFF
--- a/website/versioned_docs/version-7.1/using-react-redux/static-types.md
+++ b/website/versioned_docs/version-7.1/using-react-redux/static-types.md
@@ -61,7 +61,7 @@ export const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector
 // my-component.tsx
 import { useTypedSelector } from './reducer.ts'
 
-const isOn = useSelector(state => state.isOn)
+const isOn = useTypedSelector(state => state.isOn)
 ```
 
 ### Typing the `useDispatch` hook


### PR DESCRIPTION
The code example showing how to use a typed useSelect does not use useTypedSelector but the useSelect hook.