### PR TITLE
unnecessary extra semi colon in docs

### DIFF
--- a/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
+++ b/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
@@ -65,7 +65,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 // Later, in your application, a parent component renders:
-;<ConnectedTodo id={123} />
+<ConnectedTodo id={123} />
 // and your component receives props.id, props.todo, and props.visibilityFilter
 ```
 


### PR DESCRIPTION
in docs at https://react-redux.js.org/using-react-redux/connect-mapstate#ownprops-optional
```;<Component id={123} />```