### PR TITLE
another weird semi colon in docs

### DIFF
--- a/docs/using-react-redux/accessing-store.md
+++ b/docs/using-react-redux/accessing-store.md
@@ -56,7 +56,7 @@ const ConnectedComponent = connect(
 )(MyComponent)
 
 // Later, pass the custom context as a prop to the connected component
-;<ConnectedComponent context={MyContext} />
+<ConnectedComponent context={MyContext} />
 ```
 
 The following runtime error occurs when React Redux does not find a store in the context it is looking. For example:


### PR DESCRIPTION
found another one ! in https://react-redux.js.org/next/using-react-redux/accessing-store#providing-custom-context