### PR TITLE
Deleted dead link to "Redux with react" to eliminate redundancy

### DIFF
--- a/docs/introduction/basic-tutorial.md
+++ b/docs/introduction/basic-tutorial.md
@@ -445,7 +445,6 @@ Now we've finished a very simple example of a todo app with React Redux. All our
 
 ## Links
 
-- [Usage with React](https://redux.js.org/basics/usagewithreact)
 - [Using the React Redux Bindings](https://blog.isquaredsoftware.com/presentations/workshops/redux-fundamentals/react-redux.html)
 - [Higher Order Components in Depth](https://medium.com/@franleplant/react-higher-order-components-in-depth-cf9032ee6c3e)
 - [Computing Derived Data](https://redux.js.org/recipes/computingderiveddata#sharing-selectors-across-multiple-components)


### PR DESCRIPTION
The link at the end of the docs is dead. No need to have a link to "Using Redux with React" when that's what that doc page is about. 