### PR TITLE
Mark Redux as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,19 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^16.8.3",
-    "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
+    "react": "^16.8.3"
   },
   "peerDependenciesMeta": {
+    "@reduxjs/toolkit": {
+      "optional": true
+    },
     "react-dom": {
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "redux": {
       "optional": true
     }
   },


### PR DESCRIPTION
**TL;DR:** With the introduction of [`@reduxjs/toolkit`](/reduxjs/redux-toolkit), we can now use it in place of `redux`, thus making both peer dependencies **optional**.

As suggested by @markerikson in https://github.com/reduxjs/redux-toolkit/issues/238#issuecomment-547237742,
> One other small downside is that React-Redux says it wants Redux as a peer, and logs a warning if only RSK is installed.

Currently, this warning may very well give the false impression that `@reduxjs/toolkit` must be installed **alongside** `redux` for it to work properly.

Ideally, an `UNMET PEER DEPENDENCY` warning should by displayed **iff** neither `redux`  nor `@reduxjs/toolkit` is installed, but neither `npm` nor `yarn` has a way to specify such a requirement AFAIK. That leaves us no choice but to mark both as optional (similar to the [`react-dom`-vs-`react-native` situation](https://github.com/reduxjs/react-redux/pull/1390#issuecomment-528940544)), if we are to avoid being misleading.

In the future, leaving `redux` as is might pose a bigger problem still with `npm` v7, which will install peer dependencies automatically, as outlined in the [npm CLI Roadmap](https://github.com/npm/cli/wiki/Roadmap#proper-peerdependencies-support) among other places:
> ### Proper `peerDependencies` Support
> Part of the installer rewrite involves taking a fresh look at how `peerDependencies` are handled (and, quite often, _not_ handled) to maximize the cases where the CLI does the right thing. Since npm v3, `peerDependencies` were not installed by default, putting the onus on users to resolve them. We'll be bringing back this functionality in version 7.