### PR TITLE
A possible idea towards fixing useSelector tearing in Concurrent Mode

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -43,7 +43,7 @@ function useSelectorWithStoreAndSubscription(
     if (!equalityFn(nextSelectedState, state.selectedState)) {
       selectedState = nextSelectedState
       // schedule another update
-      dispatch(state.storeState)
+      dispatch(store.getState())
     }
   }
 


### PR DESCRIPTION
This is partly for #1351.

This tries to take the same approach as use-subscription by React team.
It's not exactly the same, because in react-redux, a selector doesn't have to be stable.
(Also noticed, equalityFn in callback is read from the closure.)

I don't fully understand #1455, but the approach is probably different.

There are three test cases failing. two of them I know why. the last one I'm not sure.

I've tested it with [my tool](https://github.com/dai-shi/will-this-react-global-state-work-in-concurrent-mode), but ideally we should add a test like the one in use-subscription.

Do we take it seriously?

Those who might be interested: @markerikson @MrWolfZ @eddyw @salvoravida