### PR TITLE
Docs: Fix typo in connect.md

### DIFF
--- a/website/versioned_docs/version-7.1/api/connect.md
+++ b/website/versioned_docs/version-7.1/api/connect.md
@@ -122,7 +122,7 @@ The second parameter is normally referred to as `ownProps` by convention.
 
 ```js
 // binds on component re-rendering
-;<button onClick={() => this.props.toggleTodo(this.props.todoId)} />
+<button onClick={() => this.props.toggleTodo(this.props.todoId)} />
 
 // binds on `props` change
 const mapDispatchToProps = (dispatch, ownProps) => {


### PR DESCRIPTION
There is werid semicolon in [connect.md](https://react-redux.js.org/api/connect#ownprops-1).

This typo is like #1484 .. 😅