### PR TITLE
docs: mapDispatchToProps returning undefined

### DIFF
--- a/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
+++ b/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
@@ -159,7 +159,9 @@ render() {
 }
 
 const mapDispatchToProps = dispatch => {
-  toggleTodo: todoId => dispatch(toggleTodo(todoId))
+  return {
+    toggleTodo: todoId => dispatch(toggleTodo(todoId))
+  }
 }
 ```
 
@@ -171,7 +173,9 @@ render() {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  toggleTodo: () => dispatch(toggleTodo(ownProps.todoId))
+  return {
+    toggleTodo: () => dispatch(toggleTodo(ownProps.todoId))
+  }
 }
 ```
 


### PR DESCRIPTION
Arrow function wasn’t returning an object, those braces were a code block.