### PR TITLE
Optimize createListenerCollection

### DIFF
--- a/test/utils/Subscription.spec.js
+++ b/test/utils/Subscription.spec.js
@@ -1,0 +1,57 @@
+import Subscription from '../../src/utils/Subscription'
+
+describe('Subscription', () => {
+  let notifications
+  let store
+  let parent
+
+  beforeEach(() => {
+    notifications = []
+    store = { subscribe: () => jest.fn() }
+
+    parent = new Subscription(store)
+    parent.onStateChange = () => {}
+    parent.trySubscribe()
+  })
+
+  function subscribeChild(name) {
+    const child = new Subscription(store, parent)
+    child.onStateChange = () => notifications.push(name)
+    child.trySubscribe()
+    return child
+  }
+
+  it('listeners are notified in order', () => {
+    subscribeChild('child1')
+    subscribeChild('child2')
+    subscribeChild('child3')
+    subscribeChild('child4')
+
+    parent.notifyNestedSubs()
+
+    expect(notifications).toEqual(['child1', 'child2', 'child3', 'child4'])
+  })
+
+  it('listeners can be unsubscribed', () => {
+    const child1 = subscribeChild('child1')
+    const child2 = subscribeChild('child2')
+    const child3 = subscribeChild('child3')
+
+    child2.tryUnsubscribe()
+    parent.notifyNestedSubs()
+
+    expect(notifications).toEqual(['child1', 'child3'])
+    notifications.length = 0
+
+    child1.tryUnsubscribe()
+    parent.notifyNestedSubs()
+
+    expect(notifications).toEqual(['child3'])
+    notifications.length = 0
+
+    child3.tryUnsubscribe()
+    parent.notifyNestedSubs()
+
+    expect(notifications).toEqual([])
+  })
+})


### PR DESCRIPTION
Follow-up to https://github.com/reduxjs/react-redux/issues/1454. Using a linked list to store listeners for fast removal. For comparison unmounting 50k connected children under a single parent.
 
**Before:**
<img width="1161" alt="before" src="https://user-images.githubusercontent.com/3285994/74685094-d2807180-51cd-11ea-8129-6c221d699614.png">

**Afterwards:**
<img width="1177" alt="afterwards" src="https://user-images.githubusercontent.com/3285994/74685106-da401600-51cd-11ea-9968-20f3cdda51e8.png">

