### PR TITLE
remove options parameter

### DIFF
--- a/src/connect/wrapMapToProps.js
+++ b/src/connect/wrapMapToProps.js
@@ -1,8 +1,8 @@
 import verifyPlainObject from '../utils/verifyPlainObject'
 
 export function wrapMapToPropsConstant(getConstant) {
-  return function initConstantSelector(dispatch, options) {
-    const constant = getConstant(dispatch, options)
+  return function initConstantSelector(dispatch) {
+    const constant = getConstant(dispatch)
 
     function constantSelector() {
       return constant


### PR DESCRIPTION
I checked the use of the wrapMapToPropsConstant function in the codebase and it is only used in wrapMapToProps and mapDispatchToProps. All three places, the function passed in doesn't take in a second parameter. This might be left over code from a previous refactor or maybe left over for some future feature that wants to pass options as a parameter into the function. However, I thought I bring it up to your attention.