### PR TITLE
Show useSelector result in React DevTools

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -1,4 +1,4 @@
-import { useReducer, useRef, useMemo, useContext } from 'react'
+import { useReducer, useRef, useMemo, useContext, useDebugValue } from 'react'
 import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
 import Subscription from '../utils/Subscription'
 import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
@@ -97,12 +97,16 @@ export function createSelectorHook(context = ReactReduxContext) {
     }
     const { store, subscription: contextSub } = useReduxContext()
 
-    return useSelectorWithStoreAndSubscription(
+    const selectedState = useSelectorWithStoreAndSubscription(
       selector,
       equalityFn,
       store,
       contextSub
     )
+
+    useDebugValue(selectedState)
+
+    return selectedState
   }
 }
 


### PR DESCRIPTION
Resolves #1525

I've checked the performance impact by calling `useSelector` 10000 times while rendering 1 component. Durations during mounts and updates:

| | Before | After |
| ------ | -------- | ------- |
| React prod, browser console is closed | 80ms, 45ms | 81ms, 45ms |
| React dev, React DevTools are opened | 100ms, 55ms | 100ms, 55ms |

The times vary a lot on each run so I've concluded that there is no noticeable performance difference and left the `useDebugValue` to be called regardless.

<details>
<summary>The benchmark code</summary>

```html
<!--<script src="https://cdn.jsdelivr.net/npm/react@16.13.0/umd/react.production.min.js"></script>-->
<!--<script src="https://cdn.jsdelivr.net/npm/react-dom@16.13.0/umd/react-dom.production.min.js"></script>-->
<script src="https://cdn.jsdelivr.net/npm/react@16.13.0/umd/react.development.js"></script>
<script src="https://cdn.jsdelivr.net/npm/react-dom@16.13.0/umd/react-dom.development.js"></script>
<script src="https://cdn.jsdelivr.net/npm/redux@4.0.5/dist/redux.min.js"></script>
<script src="./react-redux.js"></script>

<div id="app"></div>
<script>
	var hookCallCount = 10000;

	var store = Redux.createStore(function(state) {
		return state || { foo: 'bar' };
	});

	function selector(state) {
		return state.foo;
	}

	function Component() {
		for (var i = 0; i < hookCallCount; ++i) {
			ReactRedux.useSelector(selector);
		}

		return 'Ok';
	}

	function App() {
		return React.createElement(
			ReactRedux.Provider,
			{ store: store },
			React.createElement(Component),
		);
	}

	console.time('First render');
	ReactDOM.render(
		React.createElement(App),
		document.getElementById('app'),
	);
	console.timeEnd('First render');

	setTimeout(() => {
		console.time('Update');
		ReactDOM.render(
			React.createElement(App),
			document.getElementById('app'),
		);
		console.timeEnd('Update');
	}, 1000);
</script>
```

</details>

Please consider that `useDebugValue` gives no effect with a React production bundle.

I haven't found a way to test a `useDebugValue` call therefore I haven't added a test. I will add if I know how.