### PR TITLE
Fix useSelector race condition when dispatch happens in componentDidUpdate

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -42,11 +42,9 @@ function useSelectorWithStoreAndSubscription(
     throw err
   }
 
-  useIsomorphicLayoutEffect(() => {
-    latestSelector.current = selector
-    latestSelectedState.current = selectedState
-    latestSubscriptionCallbackError.current = undefined
-  })
+  latestSelector.current = selector
+  latestSelectedState.current = selectedState
+  latestSubscriptionCallbackError.current = undefined
 
   useIsomorphicLayoutEffect(() => {
     function checkForUpdates() {

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -154,6 +154,49 @@ describe('React', () => {
 
           expect(renderedItems).toEqual([0, 1])
         })
+
+        it('works properly with dispatch from componentDidUpdate', () => {
+          store = createStore(c => c + 1, -1)
+
+          const Comp = () => {
+            const selector = useCallback(c => c, [])
+            const value = useSelector(selector)
+            renderedItems.push(value)
+            return <CompClass val={value} />
+          }
+
+          class CompClass extends React.PureComponent {
+            constructor(props) {
+              super(props)
+              this.dispatched = false
+            }
+            componentDidUpdate() {
+              if (this.dispatched) {
+                return
+              }
+              store.dispatch({ type: '' })
+              this.dispatched = true
+            }
+            render() {
+              return <div />
+            }
+          }
+
+          rtl.render(
+            <ProviderMock store={store}>
+              <Comp />
+            </ProviderMock>
+          )
+
+          // The first render doesn't trigger componentDidUpdate
+          expect(renderedItems).toEqual([0])
+
+          // This dispatch forces Comp and CompClass to re-render,
+          // triggering componentDidUpdate and dispatching another action
+          store.dispatch({ type: '' })
+
+          expect(renderedItems).toEqual([0, 1, 2])
+        })
       })
 
       describe('performance optimizations and bail-outs', () => {


### PR DESCRIPTION
When an action is dispatched inside a child class component's `componentDidUpdate`, `checkForUpdates` synchronously executes before the code block in `useIsomorphicLayoutEffect`:
```
latestSelector.current = selector
latestSelectedState.current = selectedState
latestSubscriptionCallbackError.current = undefined
```

This block sets `latestSelectedState.current` to the `selectedState` value assigned by the latest render, which may be stale in comparison to the `selectedState` value gotten in `checkForUpdates`. In this case, the stale value overwrites the new value. I've added a test case which reproduces the issue.

This PR fixes the issue by moving the ref-mutating lines out of `useIsomorphicLayoutEffect`, ensuring that they execute in `useSelector`'s render step immediately. Executing during the render phase should be fine since all it's doing is updating refs to their most up-to-date value.