### PR TITLE
Fix link to connect API

### DIFF
--- a/docs/introduction/basic-tutorial.md
+++ b/docs/introduction/basic-tutorial.md
@@ -352,7 +352,7 @@ export default connect(
 )(Component)
 ```
 
-These four cases cover the most basic usages of `connect`. To read more about `connect`, continue reading our [API section](../api/connect.md) that explains it in more detail.
+These four cases cover the most basic usages of `connect`. To read more about `connect`, continue reading our [API section](../api/connect) that explains it in more detail.
 
 <!-- TODO: Put up link to the page that further explains connect -->
 


### PR DESCRIPTION
Link to connect.md works in preview but is gives 404 for website Update internal link from `../api/connect.md` to `../api/connect` to fix.