### PR TITLE
Fixed mapDispatchToProps example with parentheses

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -124,9 +124,9 @@ The second parameter is normally referred to as `ownProps` by convention.
 <button onClick={() => this.props.toggleTodo(this.props.todoId)} />
 
 // binds on `props` change
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (dispatch, ownProps) => ({
   toggleTodo: () => dispatch(toggleTodo(ownProps.todoId))
-}
+})
 ```
 
 The number of declared function parameters of `mapDispatchToProps` determines whether they receive ownProps. See notes [here](#the-arity-of-maptoprops-functions).


### PR DESCRIPTION
To return an object using the arrow function, wrap the return value in parentheses.