### PR TITLE
Rename internal forwardedRef usage

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -272,12 +272,12 @@ export default function connectAdvanced(
     const usePureOnlyMemo = pure ? useMemo : callback => callback()
 
     function ConnectFunction(props) {
-      const [propsContext, forwardedRef, wrapperProps] = useMemo(() => {
+      const [propsContext, reactReduxForwardedRef, wrapperProps] = useMemo(() => {
         // Distinguish between actual "data" props that were passed to the wrapper component,
         // and values needed to control behavior (forwarded refs, alternate context instances).
         // To maintain the wrapperProps object reference, memoize this destructuring.
-        const { forwardedRef, ...wrapperProps } = props
-        return [props.context, forwardedRef, wrapperProps]
+        const { reactReduxForwardedRef, ...wrapperProps } = props
+        return [props.context, reactReduxForwardedRef, wrapperProps]
       }, [props])
 
       const ContextToUse = useMemo(() => {
@@ -437,8 +437,8 @@ export default function connectAdvanced(
       // Now that all that's done, we can finally try to actually render the child component.
       // We memoize the elements for the rendered child component as an optimization.
       const renderedWrappedComponent = useMemo(
-        () => <WrappedComponent {...actualChildProps} ref={forwardedRef} />,
-        [forwardedRef, WrappedComponent, actualChildProps]
+        () => <WrappedComponent {...actualChildProps} ref={reactReduxForwardedRef} />,
+        [reactReduxForwardedRef, WrappedComponent, actualChildProps]
       )
 
       // If React sees the exact same element reference as last time, it bails out of re-rendering
@@ -472,7 +472,7 @@ export default function connectAdvanced(
         props,
         ref
       ) {
-        return <Connect {...props} forwardedRef={ref} />
+        return <Connect {...props} reactReduxForwardedRef={ref} />
       })
 
       forwarded.displayName = displayName


### PR DESCRIPTION
This addresses issue https://github.com/reduxjs/react-redux/issues/1552, where if a parent passes in a `forwardedRef` prop to a connected component (with default options), the connected child will not receive this prop. This change has the same issue with the prop `reactReduxForwardedRef`, but `forwardedRef` is a prop name commonly used and provided in [React's documentation](https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-in-higher-order-components), so `reactReduxForwardedRef` is much less likely to be used elsewhere.

I'm happy to choose a name other than `reactReduxForwardedRef` if there are any suggestions, I went with something that would hopefully be clear that it is for internal use only and would be unlikely to be used by any other codebase.

A bit of context for why I'm proposing this change, if it helps. I migrated a large codebase from `react-redux` v5 to v7 recently. This codebase had a lot of instances of refs being passed down as a `forwardedRef` prop (per the suggestion in React's documentation). Many of our components are connected components in order to access feature flags. The upgrade broke all cases where a `forwardedRef` prop was passed through a connected component. I fixed this in the codebase by renaming all of these props `refToForward` and making a lint rule to forbid the use of `forwardedRef`. This was a little silly, but was a high confidence way to resolve the issue. I believe `connect` swallowing `forwardedRef` props is a very minor pain point and can cause confusion for developers, and since the fix isn't too involved I'm of the opinion it's worth doing.

It's your all's library though, and I understand if you don't want to merge this. Thanks for all the you do!