### PR TITLE
removed a redundant object creation when using forceUpdate

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -66,7 +66,7 @@ function useSelectorWithStoreAndSubscription(
         latestSubscriptionCallbackError.current = err
       }
 
-      forceRender({})
+      forceRender()
     }
 
     subscription.onStateChange = checkForUpdates


### PR DESCRIPTION
there's no need to pass an object to `forceRender` like this: `forceRender({})`

this is enough: `forceRender()` and saves us a redundant object creation.

notice the example in the official react docs:
https://reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate