### PR TITLE
extract and improve force render to be a custom hook "useForceRender"

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -1,8 +1,9 @@
-import { useReducer, useRef, useMemo, useContext, useDebugValue } from 'react'
+import { useRef, useMemo, useContext, useDebugValue } from 'react'
 import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
 import Subscription from '../utils/Subscription'
 import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
 import { ReactReduxContext } from '../components/Context'
+import { useForceRender } from '../utils/customHooks'
 
 const refEquality = (a, b) => a === b
 
@@ -12,7 +13,7 @@ function useSelectorWithStoreAndSubscription(
   store,
   contextSub
 ) {
-  const [, forceRender] = useReducer(s => s + 1, 0)
+  const forceRender = useForceRender()
 
   const subscription = useMemo(() => new Subscription(store, contextSub), [
     store,

--- a/src/utils/customHooks.js
+++ b/src/utils/customHooks.js
@@ -1,0 +1,5 @@
+import { useReducer } from 'react'
+
+// based on https://reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+const forceRenderFn = s => s + 1
+export const useForceRender = () => useReducer(forceRenderFn, 0)[1]

--- a/test/utils/customHooks.spec.js
+++ b/test/utils/customHooks.spec.js
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react'
+import * as rtl from '@testing-library/react'
+import { useForceRender } from '../../src/utils/customHooks'
+
+describe('customHooks', () => {
+  describe('useForceRender', () => {
+    it('re-render on using forceRender', () => {
+      let renders = 0
+      const Comp = () => {
+        renders++
+
+        const forceRender = useForceRender()
+
+        useEffect(() => {
+          forceRender()
+        }, [])
+
+        return <div />
+      }
+
+      rtl.render(<Comp />)
+
+      expect(renders).toEqual(2)
+    })
+  })
+})


### PR DESCRIPTION
1. now it's reusable
2. it won't re-create the function inside the "useReducer" function it uses internally for each hook on every single render, instead it has only one instance of this function now (`forceRenderFn`)
3. added a test to ensure it works as expected