### PR TITLE
Fix error message typo in useSelector ('You must pass a selector...).

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -97,7 +97,7 @@ export function createSelectorHook(context = ReactReduxContext) {
       : () => useContext(context)
   return function useSelector(selector, equalityFn = refEquality) {
     if (process.env.NODE_ENV !== 'production' && !selector) {
-      throw new Error(`You must pass a selector to useSelectors`)
+      throw new Error(`You must pass a selector to useSelector`)
     }
     const { store, subscription: contextSub } = useReduxContext()
 


### PR DESCRIPTION
This is a tiny edit, but the current wording did send me hunting for `useSelectors` in the source.