### PR TITLE
Apply React.memo twice to ensure that props object reference stays the same

### DIFF
--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -471,7 +471,8 @@ export default function connectAdvanced(
     }
 
     // If we're in "pure" mode, ensure our wrapper component only re-renders when incoming props have changed.
-    const Connect = pure ? React.memo(ConnectFunction) : ConnectFunction
+    // Applying React.memo twice ensures that props object reference doesn't change unless some of the props has changed.
+    const Connect = pure ? React.memo(React.memo(ConnectFunction)) : ConnectFunction
 
     Connect.WrappedComponent = WrappedComponent
     Connect.displayName = displayName

--- a/src/components/connectAdvanced.js
+++ b/src/components/connectAdvanced.js
@@ -471,8 +471,10 @@ export default function connectAdvanced(
     }
 
     // If we're in "pure" mode, ensure our wrapper component only re-renders when incoming props have changed.
-    // Applying React.memo twice ensures that props object reference doesn't change unless some of the props has changed.
-    const Connect = pure ? React.memo(React.memo(ConnectFunction)) : ConnectFunction
+    const Connect = pure
+      ? // Applying React.memo twice ensures that props object reference doesn't change unless some of the props has changed.
+        React.memo(React.memo(ConnectFunction))
+      : ConnectFunction
 
     Connect.WrappedComponent = WrappedComponent
     Connect.displayName = displayName


### PR DESCRIPTION
See https://github.com/facebook/react/issues/18901

Ideally, it should be fixed on React side though