### PR TITLE
docs(hooks.md): clarify `useDispatch`, see #1468

### DIFF
--- a/website/versioned_docs/version-7.1/api/hooks.md
+++ b/website/versioned_docs/version-7.1/api/hooks.md
@@ -218,6 +218,8 @@ const dispatch = useDispatch()
 
 This hook returns a reference to the `dispatch` function from the Redux store. You may use it to dispatch actions as needed.
 
+*Note: like in [React's `useReducer`](https://reactjs.org/docs/hooks-reference.html#usereducer), the returned `dispatch` function identity is stable and won't change on re-renders (unless you change the `store` being passed to the `<Provider>`, which would be extremely unusual).*
+
 #### Examples
 
 ```jsx
@@ -238,7 +240,7 @@ export const CounterComponent = ({ value }) => {
 }
 ```
 
-When passing a callback using `dispatch` to a child component, it is recommended to memoize it with `useCallback`, since otherwise child components may render unnecessarily due to the changed reference.
+Reminder: when passing a callback using `dispatch` to a child component, you should memoize it with [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback), just like you should memoize any passed callback. This avoids unnecesarry rendering of child components due to the changed callback reference. You can safely pass `[dispatch]` in the dependency array for the `useCallback` call - since `dispatch` won't change, the callback will be reused properly (as it should). For example:
 
 ```jsx
 import React, { useCallback } from 'react'

--- a/website/versioned_docs/version-7.2/api/hooks.md
+++ b/website/versioned_docs/version-7.2/api/hooks.md
@@ -220,6 +220,8 @@ const dispatch = useDispatch()
 
 This hook returns a reference to the `dispatch` function from the Redux store. You may use it to dispatch actions as needed.
 
+*Note: like in [React's `useReducer`](https://reactjs.org/docs/hooks-reference.html#usereducer), the returned `dispatch` function identity is stable and won't change on re-renders (unless you change the `store` being passed to the `<Provider>`, which would be extremely unusual).*
+
 #### Examples
 
 ```jsx
@@ -240,7 +242,7 @@ export const CounterComponent = ({ value }) => {
 }
 ```
 
-When passing a callback using `dispatch` to a child component, it is recommended to memoize it with `useCallback`, since otherwise child components may render unnecessarily due to the changed reference.
+Reminder: when passing a callback using `dispatch` to a child component, you should memoize it with [`useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback), just like you should memoize any passed callback. This avoids unnecesarry rendering of child components due to the changed callback reference. You can safely pass `[dispatch]` in the dependency array for the `useCallback` call - since `dispatch` won't change, the callback will be reused properly (as it should). For example:
 
 ```jsx
 import React, { useCallback } from 'react'


### PR DESCRIPTION
This PR is a mirror of my previous PR #1598, updating the versioned docs as [mentioned](https://github.com/reduxjs/react-redux/pull/1598#issuecomment-651927710) by @markerikson.