### PR TITLE
Fixes Links In Docs Page

### DIFF
--- a/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
+++ b/docs/using-react-redux/connect-extracting-data-with-mapStateToProps.md
@@ -224,5 +224,5 @@ function mapStateToProps(...args) {
 
 - [Why Is My Component Re-Rendering Too Often?](https://redux.js.org/faq/react-redux#why-is-my-component-re-rendering-too-often)
 - [Why isn't my component re-rendering, or my mapStateToProps running](https://redux.js.org/faq/react-redux#why-isnt-my-component-re-rendering-or-my-mapstatetoprops-running)
-- [How can I speed up my mapStateToProps?](https://redux.js.org/faq/react-redux#why-is-my-component-re-rendering-too-often)
-- [Should I only connect my top component, or can I connect multiple components in my tree?](https://redux.js.org/faq/react-redux#why-is-my-component-re-rendering-too-often)
+- [How can I speed up my mapStateToProps?](https://redux.js.org/faq/react-redux#how-can-i-speed-up-my-mapstatetoprops)
+- [Should I only connect my top component, or can I connect multiple components in my tree?](https://redux.js.org/faq/react-redux#should-i-only-connect-my-top-component-or-can-i-connect-multiple-components-in-my-tree)


### PR DESCRIPTION
Just a few fixes in the links at the bottom of [Connect: Extracting Data with mapStateToProps](https://react-redux.js.org/using-react-redux/connect-mapstate) docs page.