### PR TITLE
fix mapDispatchToProps ownProps example description

### DIFF
--- a/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
+++ b/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
@@ -151,7 +151,7 @@ If your `mapDispatchToProps` function is declared as taking two parameters, it w
 
 This means, instead of re-binding new `props` to action dispatchers upon component re-rendering, you may do so when your component's `props` change.
 
-**Binds on component re-rendering**
+**Binds on component mount**
 
 ```js
 render() {

--- a/website/versioned_docs/version-7.2/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
+++ b/website/versioned_docs/version-7.2/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
@@ -152,7 +152,7 @@ If your `mapDispatchToProps` function is declared as taking two parameters, it w
 
 This means, instead of re-binding new `props` to action dispatchers upon component re-rendering, you may do so when your component's `props` change.
 
-**Binds on component re-rendering**
+**Binds on component mount**
 
 ```js
 render() {


### PR DESCRIPTION
When using mapDispatchToProps we re-binding the props on component mount and not on re0rendering like the current docs mentions.

This fixes it. 