### PR TITLE
Upgrade react peer dependency to v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^16.8.3",
+    "react": "^16.8.3 || ^17",
     "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Fixes #1646

This PR only meets peerDependency, a dependency upgrade and version bump might be needed in order to support v17 completely.