### PR TITLE
Add info about useAppDispatch to docs

### DIFF
--- a/docs/using-react-redux/static-types.md
+++ b/docs/using-react-redux/static-types.md
@@ -80,6 +80,11 @@ export type AppDispatch = typeof store.dispatch
 // MyComponent.tsx
 const dispatch: AppDispatch = useDispatch()
 ```
+You may also find it to be more convenient to export a hook like `useAppDispatch` shown below, then using it wherever you'd call `useDispatch`:
+```ts
+export type AppDispatch = typeof store.dispatch
+export const useAppDispatch = () => useDispatch<AppDispatch>() // Export a hook that can be reused to resolve types
+```
 
 ### Typing the `connect` higher order component
 


### PR DESCRIPTION
As discussed [here](https://github.com/reduxjs/react-redux/issues/1650#issuecomment-714702841), docs need to be updated with information about `useAppDispatch`. Same info can be found in [redux toolkit](https://redux-toolkit.js.org/usage/usage-with-typescript#getting-the-dispatch-type) docs.