### PR TITLE
Additional TS usage updates

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,23 +1,46 @@
 module.exports = {
-  docs: {
-    Introduction: [
-      'introduction/getting-started',
-      'introduction/why-use-react-redux'
-    ],
-    Tutorials: ['tutorials/connect'],
-    'Using React Redux': [
-      'using-react-redux/usage-with-typescript',
-      'using-react-redux/connect-mapstate',
-      'using-react-redux/connect-mapdispatch',
-      'using-react-redux/accessing-store'
-    ],
-    'API Reference': [
-      'api/provider',
-      'api/hooks',
-      'api/connect',
-      'api/connect-advanced',
-      'api/batch'
-    ],
-    Guides: ['troubleshooting']
-  }
+  docs: [
+    {
+      type: 'category',
+      label: 'Introduction',
+      collapsed: false,
+      items: [
+        'introduction/getting-started',
+        'introduction/why-use-react-redux'
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Tutorials',
+      collapsed: false,
+      items: ['tutorials/connect']
+    },
+    {
+      type: 'category',
+      label: 'Using React Redux',
+      collapsed: false,
+      items: [
+        'using-react-redux/usage-with-typescript',
+        'using-react-redux/connect-mapstate',
+        'using-react-redux/connect-mapdispatch',
+        'using-react-redux/accessing-store'
+      ]
+    },
+    {
+      type: 'category',
+      label: 'API Reference',
+      items: [
+        'api/provider',
+        'api/hooks',
+        'api/connect',
+        'api/connect-advanced',
+        'api/batch'
+      ]
+    },
+    {
+      type: 'category',
+      label: 'Guides',
+      items: ['troubleshooting']
+    }
+  ]
 }


### PR DESCRIPTION
This PR:

- Reworks the sidebars setup to expand Intro, Tutorials, and Usage categories by default
- Updates the TS Usage page to match the same store setup from the other docs pages, and clarify the alternate approaches for usage