### PR TITLE
Don't re-run the selector after update

### DIFF
--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -64,15 +64,15 @@ function useSelectorWithStoreAndSubscription(
   useIsomorphicLayoutEffect(() => {
     function checkForUpdates() {
       try {
-        const storeState = store.getState()
-        const newSelectedState = latestSelector.current(storeState)
+        const newStoreState = store.getState()
+        const newSelectedState = latestSelector.current(newStoreState)
 
         if (equalityFn(newSelectedState, latestSelectedState.current)) {
           return
         }
 
         latestSelectedState.current = newSelectedState
-        latestStoreState.current = storeState
+        latestStoreState.current = newStoreState
       } catch (err) {
         // we ignore all errors here, since when the component
         // is re-rendered, the selectors are called again, and

--- a/src/hooks/useSelector.js
+++ b/src/hooks/useSelector.js
@@ -64,13 +64,15 @@ function useSelectorWithStoreAndSubscription(
   useIsomorphicLayoutEffect(() => {
     function checkForUpdates() {
       try {
-        const newSelectedState = latestSelector.current(store.getState())
+        const storeState = store.getState()
+        const newSelectedState = latestSelector.current(storeState)
 
         if (equalityFn(newSelectedState, latestSelectedState.current)) {
           return
         }
 
         latestSelectedState.current = newSelectedState
+        latestStoreState.current = storeState
       } catch (err) {
         // we ignore all errors here, since when the component
         // is re-rendered, the selectors are called again, and

--- a/test/hooks/useSelector.spec.js
+++ b/test/hooks/useSelector.spec.js
@@ -38,17 +38,21 @@ describe('React', () => {
         })
 
         it('selects the state and renders the component when the store updates', () => {
-          const { result } = renderHook(() => useSelector((s) => s.count), {
+          const selector = jest.fn((s) => s.count)
+
+          const { result } = renderHook(() => useSelector(selector), {
             wrapper: (props) => <ProviderMock {...props} store={store} />,
           })
 
           expect(result.current).toEqual(0)
+          expect(selector).toHaveBeenCalledTimes(2)
 
           act(() => {
             store.dispatch({ type: '' })
           })
 
           expect(result.current).toEqual(1)
+          expect(selector).toHaveBeenCalledTimes(3)
         })
       })
 


### PR DESCRIPTION
Fixes #1697

We can avoid running the selector twice by setting the latestStoreState at the same time as setting the latestSelectedState. If the store state hasn't changed, then the selector won't as well (since it's pure).