### PR TITLE
Removed Useless Symbol - Docs

### DIFF
--- a/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
+++ b/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md
@@ -297,7 +297,7 @@ Note that:
 
 ```js
 // React Redux does this for you automatically:
-;(dispatch) => bindActionCreators(mapDispatchToProps, dispatch)
+(dispatch) => bindActionCreators(mapDispatchToProps, dispatch)
 ```
 
 Therefore, our `mapDispatchToProps` can simply be:


### PR DESCRIPTION
Found another useless semicolon while reading the docs,
These might be caused by, [prettier (docs)](https://prettier.io/docs/en/rationale.html#semicolons)