### PR TITLE
docs: add link to source in getting-started.md

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -41,7 +41,7 @@ If you are using TypeScript, the React Redux types are maintained separately in 
 npm install @types/react-redux
 ```
 
-The code used for this example is almost the same as the [official Redux+JS template](https://github.com/reduxjs/cra-template-redux). Additionally the same code template for typescript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
+The code used for this example is based on the [official Redux+JS template](https://github.com/reduxjs/cra-template-redux). Additionally the same code template for typescript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
 
 ## `Provider`
 

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -41,7 +41,7 @@ If you are using TypeScript, the React Redux types are maintained separately in 
 npm install @types/react-redux
 ```
 
-The code used for this example is almost the same as the [official Redux+JS template](https://github.com/reduxjs/cra-template-redux). Additionally the same code template, but for typescript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
+The code used for this example is almost the same as the [official Redux+JS template](https://github.com/reduxjs/cra-template-redux). Additionally the same code template for typescript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
 
 ## `Provider`
 

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -41,7 +41,7 @@ If you are using TypeScript, the React Redux types are maintained separately in 
 npm install @types/react-redux
 ```
 
-The code used for this example is based on the [official Redux+JS template](https://github.com/reduxjs/cra-template-redux). Additionally the same code template for typescript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
+The code used for this example is based on the [official Redux template](https://github.com/reduxjs/cra-template-redux). Additionally, the same code template for TypeScript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
 
 ## `Provider`
 

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -41,6 +41,8 @@ If you are using TypeScript, the React Redux types are maintained separately in 
 npm install @types/react-redux
 ```
 
+The code used for this example is almost the same as the [official Redux+JS template](https://github.com/reduxjs/cra-template-redux). Additionally the same code template, but for typescript can be found [here](https://github.com/reduxjs/cra-template-redux-typescript).
+
 ## `Provider`
 
 React Redux includes a `<Provider />` component, which makes the Redux store available to the rest of your app:


### PR DESCRIPTION
I had a look at the "An Existing React App" chapter today. I found the code examples great, but was missing the link to the full code. To be honest I only "stumbled" to it via another page later. I think it's helpful if it's linked directly in this chapter.