### PR TITLE
Bump @testing-library/react to 12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@rollup/plugin-replace": "^2.3.3",
         "@testing-library/jest-dom": "^5.11.5",
         "@testing-library/jest-native": "^3.4.3",
-        "@testing-library/react": "^11.2.7",
+        "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^3.4.2",
         "@testing-library/react-native": "^7.1.0",
         "babel-eslint": "^10.1.0",
@@ -6937,9 +6937,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "7.31.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.0.0.tgz",
+      "integrity": "sha512-Ym375MTOpfszlagRnTMO+FOfTt6gRrWiDOWmEnWLu9OvwCPOWtK6i5pBHmZ07wUJiQ7wWz0t8+ZBK2wFo2tlew==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -6949,26 +6949,26 @@
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.6",
         "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
+        "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/@testing-library/dom/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
+      "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^15.0.0",
+        "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0"
       },
       "engines": {
-        "node": ">= 10.14.2"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@testing-library/dom/node_modules/@types/istanbul-reports": {
@@ -6981,9 +6981,9 @@
       }
     },
     "node_modules/@testing-library/dom/node_modules/@types/yargs": {
-      "version": "15.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -7051,18 +7051,30 @@
       }
     },
     "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
+      "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^26.6.2",
+        "@jest/types": "^27.0.2",
         "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
+        "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@testing-library/dom/node_modules/react-is": {
@@ -7208,16 +7220,16 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.0.0.tgz",
+      "integrity": "sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@testing-library/dom": "^8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "peerDependencies": {
         "react": "*",
@@ -31880,9 +31892,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.31.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.0.0.tgz",
+      "integrity": "sha512-Ym375MTOpfszlagRnTMO+FOfTt6gRrWiDOWmEnWLu9OvwCPOWtK6i5pBHmZ07wUJiQ7wWz0t8+ZBK2wFo2tlew==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -31892,19 +31904,19 @@
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.6",
         "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
+        "pretty-format": "^27.0.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
+          "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
-            "@types/yargs": "^15.0.0",
+            "@types/yargs": "^16.0.0",
             "chalk": "^4.0.0"
           }
         },
@@ -31918,9 +31930,9 @@
           }
         },
         "@types/yargs": {
-          "version": "15.0.13",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "version": "16.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+          "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -31967,15 +31979,23 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
+          "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.6.2",
+            "@jest/types": "^27.0.2",
             "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
+            "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
           }
         },
         "react-is": {
@@ -32095,13 +32115,13 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.0.0.tgz",
+      "integrity": "sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@testing-library/dom": "^8.0.0"
       }
     },
     "@testing-library/react-hooks": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@rollup/plugin-replace": "^2.3.3",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/jest-native": "^3.4.3",
-    "@testing-library/react": "^11.2.7",
+    "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^3.4.2",
     "@testing-library/react-native": "^7.1.0",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
[`@testing-library/react@12.0.0` release](https://github.com/testing-library/react-testing-library/releases/tag/v12.0.0) includes a list of breaking changes. Seems like you're unaffected.

The next major will use concurrent rendering by default if React 18 is installed so I want to make sure any test failures are only happening due to switching to concurrent rendering.