### PR TITLE
chore(mapStateToProps): port to typescript

### DIFF
--- a/src/connect/mapStateToProps.ts
+++ b/src/connect/mapStateToProps.ts
@@ -1,12 +1,16 @@
-import { wrapMapToPropsConstant, wrapMapToPropsFunc } from './wrapMapToProps'
+import {
+  MapToProps,
+  wrapMapToPropsConstant,
+  wrapMapToPropsFunc,
+} from './wrapMapToProps'
 
-export function whenMapStateToPropsIsFunction(mapStateToProps) {
+export function whenMapStateToPropsIsFunction(mapStateToProps?: MapToProps) {
   return typeof mapStateToProps === 'function'
     ? wrapMapToPropsFunc(mapStateToProps, 'mapStateToProps')
     : undefined
 }
 
-export function whenMapStateToPropsIsMissing(mapStateToProps) {
+export function whenMapStateToPropsIsMissing(mapStateToProps?: MapToProps) {
   return !mapStateToProps ? wrapMapToPropsConstant(() => ({})) : undefined
 }
 

--- a/src/connect/wrapMapToProps.ts
+++ b/src/connect/wrapMapToProps.ts
@@ -1,17 +1,23 @@
 import { Dispatch } from 'redux'
 
+import { FixTypeLater } from '../types'
 import verifyPlainObject from '../utils/verifyPlainObject'
 
 export type MapToProps = {
-  (stateOrDispatch: any, ownProps?: any): any
+  (stateOrDispatch: FixTypeLater, ownProps?: unknown): FixTypeLater
   dependsOnOwnProps: boolean
 }
 
 export function wrapMapToPropsConstant(
-  getConstant: (dispatch: Dispatch, options: any) => void
+  // * Note:
+  //  It seems that the dispatch identifier here
+  //  could be dispatch in some cases (ex: whenMapDispatchToPropsIsMissing)
+  // and state in some others (ex: whenMapStateToPropsIsMissing)
+  //
+  getConstant: (dispatch: Dispatch) => FixTypeLater
 ) {
-  return function initConstantSelector(dispatch: Dispatch, options: any) {
-    const constant = getConstant(dispatch, options)
+  return function initConstantSelector(dispatch: Dispatch) {
+    const constant = getConstant(dispatch)
 
     function constantSelector() {
       return constant
@@ -52,9 +58,9 @@ export function wrapMapToPropsFunc(mapToProps: MapToProps, methodName: string) {
     { displayName }: { displayName: string }
   ) {
     const proxy = function mapToPropsProxy(
-      stateOrDispatch: any,
-      ownProps: any
-    ): any {
+      stateOrDispatch: FixTypeLater,
+      ownProps: unknown
+    ): FixTypeLater {
       return proxy.dependsOnOwnProps
         ? proxy.mapToProps(stateOrDispatch, ownProps)
         : proxy.mapToProps(stateOrDispatch, null)
@@ -64,8 +70,8 @@ export function wrapMapToPropsFunc(mapToProps: MapToProps, methodName: string) {
     proxy.dependsOnOwnProps = true
 
     proxy.mapToProps = function detectFactoryAndVerify(
-      stateOrDispatch: any,
-      ownProps: any
+      stateOrDispatch: FixTypeLater,
+      ownProps: unknown
     ) {
       proxy.mapToProps = mapToProps
       proxy.dependsOnOwnProps = getDependsOnOwnProps(mapToProps)

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2660,7 +2660,7 @@ describe('React', () => {
           store.dispatch({ type: 'test' })
         })
 
-        expect(initialOwnProps).toBe(undefined)
+        expect(initialOwnProps).toBe(null)
         expect(initialState).not.toBe(undefined)
         expect(secondaryOwnProps).not.toBe(undefined)
         expect(secondaryOwnProps.name).toBe('a')

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2660,7 +2660,7 @@ describe('React', () => {
           store.dispatch({ type: 'test' })
         })
 
-        expect(initialOwnProps).toBe(null)
+        expect(initialOwnProps).toBe(undefined)
         expect(initialState).not.toBe(undefined)
         expect(secondaryOwnProps).not.toBe(undefined)
         expect(secondaryOwnProps.name).toBe('a')


### PR DESCRIPTION
Hi folks 👋 

⚠️ : Lot of `any` there. I have to make a second pass to add generics. But feel free to give me feedback anyway.

This pull request follows the typescript migration initiative (#1737).

files to migrate:
- `mapStateToProps`
- `wrapMapToProps`