### PR TITLE
feature/rename unsafe lifecycles

### DIFF
--- a/src/components/Provider.js
+++ b/src/components/Provider.js
@@ -35,7 +35,7 @@ export default class Provider extends Component {
 }
 
 if (process.env.NODE_ENV !== 'production') {
-  Provider.prototype.componentWillReceiveProps = function (nextProps) {
+  Provider.prototype.UNSAFE_componentWillReceiveProps = function (nextProps) {
     const { store } = this
     const { store: nextStore } = nextProps
 

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -363,5 +363,5 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
     }
 
     return hoistStatics(Connect, WrappedComponent)
-  };
+  }
 }

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -212,7 +212,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
         this.trySubscribe()
       }
 
-      componentWillReceiveProps(nextProps) {
+      UNSAFE_componentWillReceiveProps(nextProps) {
         if (!pure || !shallowEqual(nextProps, this.props)) {
           this.haveOwnPropsChanged = true
         }
@@ -350,7 +350,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
     }
 
     if (process.env.NODE_ENV !== 'production') {
-      Connect.prototype.componentWillUpdate = function componentWillUpdate() {
+      Connect.prototype.UNSAFE_componentWillUpdate = function componentWillUpdate() {
         if (this.version === version) {
           return
         }
@@ -363,5 +363,5 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
     }
 
     return hoistStatics(Connect, WrappedComponent)
-  }
+  };
 }


### PR DESCRIPTION
We're still running react-redux@v4 to support some pages that use redux-form ( 😢, notoriously hard to upgrade ). Could we maybe create a release of v4 that has the unsafe lifecycles prefixed with `UNSAFE_`? Maybe a next minor 4.5?

In this PR I ran the codemod on `src/` let me know if we can do something like this, otherwise we'll patch locally.