### PR TITLE
Refactor: move d.ts file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "outDir": "./lib",
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "types"],
   "exclude": ["node_modules", "dist"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 declare module 'react-dom' {
   export function unstable_batchedUpdates<A, B>(
     callback: (a: A, b: B) => any,
@@ -22,4 +23,10 @@ declare module 'react-native' {
     a: A
   ): void
   export function unstable_batchedUpdates(callback: () => any): void
+}
+
+declare module 'react-is' {
+  import * as React from 'react'
+  export function isContextConsumer(value: any): value is React.ReactElement
+  export function isValidElementType(value: any): value is React.ElementType
 }


### PR DESCRIPTION
Hello @markerikson 
Relating to your last comment  https://github.com/reduxjs/react-redux/pull/1746#issuecomment-871041574, i have made a small change to avoid any possible problems. The custom types for the external dependencies will be outside of src and they will be ignored from the build process.

I'm not so sure if it's worth having these custom types, maybe it would be easier to install the @types/* of these dependencies. What do you think?


