### PR TITLE
Update Babel config for modern output

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,17 +1,25 @@
 const { NODE_ENV, BABEL_ENV } = process.env
 const cjs = NODE_ENV === 'test' || BABEL_ENV === 'commonjs'
-const loose = true
 
 module.exports = {
   presets: [
-    ['@babel/env', { loose, modules: false }],
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          esmodules: true,
+        },
+        // Use the equivalent of `babel-preset-modules`
+        bugfixes: true,
+        modules: false,
+      },
+    ],
     '@babel/preset-typescript',
   ],
   plugins: [
     ['@babel/proposal-decorators', { legacy: true }],
-    ['@babel/proposal-object-rest-spread', { loose }],
     '@babel/transform-react-jsx',
-    cjs && ['@babel/transform-modules-commonjs', { loose }],
+    cjs && ['@babel/transform-modules-commonjs'],
     [
       '@babel/transform-runtime',
       {
@@ -22,4 +30,7 @@ module.exports = {
       },
     ],
   ].filter(Boolean),
+  assumptions: {
+    enumerableModuleMeta: true,
+  },
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "es"
   ],
   "scripts": {
-    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --extensions \".js,.ts\" --out-dir lib",
-    "build:es": "babel src --extensions \".js,.ts\" --out-dir es",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --extensions \".js,.ts,.tsx\" --out-dir lib",
+    "build:es": "babel src --extensions \".js,.ts,.tsx\" --out-dir es",
     "build:umd": "cross-env NODE_ENV=development rollup -c -o dist/react-redux.js",
     "build:umd:min": "cross-env NODE_ENV=production rollup -c -o dist/react-redux.min.js",
     "build:types": "tsc",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,6 +33,7 @@ const config = {
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify(env),
+      preventAssignment: true,
     }),
     commonjs(),
   ],


### PR DESCRIPTION
- Switched babelrc to use recommended settings for "modern JS", with `targets: esmodules` and `bugfixes: true`
- Fixed missing .tsx extensions in build scripts
- Silenced Rollup warning about missing flag