### PR TITLE
chore: modify jest config, ts-jest => 26.xx.xx, tsconfig'include add …

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,9 @@
-const { default: tsJestPreset } = require('ts-jest')
-
 const defaults = {
-  ...tsJestPreset,
   coverageDirectory: './coverage/',
   collectCoverage: true,
   testURL: 'http://localhost',
 }
-
-const testFolderPath = (folderName) =>
-  `<rootDir>/test/${folderName}/**/*.{js,ts,tsx}`
+const testFolderPath = (folderName) => `<rootDir>/test/${folderName}/**/*.js`
 
 const NORMAL_TEST_FOLDERS = ['components', 'hooks', 'integration', 'utils']
 
@@ -16,6 +11,16 @@ const standardConfig = {
   ...defaults,
   displayName: 'ReactDOM',
   testMatch: NORMAL_TEST_FOLDERS.map(testFolderPath),
+}
+
+const tsTestFolderPath = (folderName) =>
+  `<rootDir>/test/${folderName}/**/*.{ts,tsx}`
+
+const tsStandardConfig = {
+  ...defaults,
+  displayName: 'ReactDOM',
+  preset: 'ts-jest',
+  testMatch: NORMAL_TEST_FOLDERS.map(tsTestFolderPath),
 }
 
 const rnConfig = {
@@ -29,5 +34,5 @@ const rnConfig = {
 }
 
 module.exports = {
-  projects: [standardConfig, rnConfig],
+  projects: [tsStandardConfig, standardConfig, rnConfig],
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.32.1",
     "rollup-plugin-terser": "^7.0.2",
-    "ts-jest": "^27.0.3",
+    "ts-jest": "26.5.6",
     "typescript": "^4.3.4"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "rollup": "^2.32.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "26.5.6",
-    "typescript": "3.9"
+    "typescript": "^4.3.4"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "rollup": "^2.32.1",
     "rollup-plugin-terser": "^7.0.2",
     "ts-jest": "26.5.6",
-    "typescript": "^4.3.4"
+    "typescript": "3.9"
   },
   "browserify": {
     "transform": [

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -15,7 +15,7 @@ export interface ProviderProps<A extends Action = AnyAction> {
    * If this is used, generate own connect HOC by using connectAdvanced, supplying the same context provided to the
    * Provider. Initial value doesn't matter, as it is overwritten with the internal state of Provider.
    */
-  context?: Context<ReactReduxContextValue>
+  context?: Context<ReactReduxContextValue | null>
   children: ReactNode
 }
 

--- a/src/connect/wrapMapToProps.ts
+++ b/src/connect/wrapMapToProps.ts
@@ -47,7 +47,7 @@ export function wrapMapToPropsConstant(
 // A length of zero is assumed to mean mapToProps is getting args via arguments or ...args and
 // therefore not reporting its length accurately..
 export function getDependsOnOwnProps(mapToProps: MapToProps) {
-  return mapToProps?.dependsOnOwnProps
+  return mapToProps.dependsOnOwnProps
     ? Boolean(mapToProps.dependsOnOwnProps)
     : mapToProps.length !== 1
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,6 +272,6 @@ export type ResolveArrayThunks<TDispatchProps extends ReadonlyArray<any>> =
 export interface TypedUseSelectorHook<TState> {
   <TSelected>(
     selector: (state: TState) => TSelected,
-    equalityFn?: (left: TSelected, right: TSelected) => boolean
+    equalityFn?: EqualityFn<TSelected>
   ): TSelected
 }

--- a/test/components/hooks.spec.tsx
+++ b/test/components/hooks.spec.tsx
@@ -43,7 +43,7 @@ describe('React', () => {
       const mapStateSpy1 = jest.fn()
       const renderSpy1 = jest.fn()
 
-      let component1StateList
+      let component1StateList: number[]
 
       const component1Decorator = connect<
         Omit<RootStateType, 'byId'>,
@@ -77,23 +77,31 @@ describe('React', () => {
       const mapStateSpy2 = jest.fn()
       const renderSpy2 = jest.fn()
 
-      interface Component2PropsType {
-        mappedProp: Array<string>
+      interface Component2Tstate {
+        mappedProp: string[]
       }
       const component2Decorator = connect<
-        Component2PropsType,
+        Component2Tstate,
         unknown,
         Omit<RootStateType, 'byId'>,
         RootStateType
-      >((state, ownProps) => {
-        mapStateSpy2()
+      >(
+        (
+          state: RootStateType,
+          ownProps: Omit<RootStateType, 'byId'>
+        ): Component2Tstate => {
+          mapStateSpy2()
 
-        return {
-          mappedProp: ownProps.list.map((id) => state.byId[id]),
+          return {
+            mappedProp: ownProps.list.map((id) => state.byId[id]),
+          }
         }
-      })
+      )
+      interface Component2PropsType {
+        list: number[]
+      }
 
-      const component2 = (props) => {
+      const component2 = (props: Component2PropsType) => {
         renderSpy2()
 
         expect(props.list).toBe(component1StateList)

--- a/test/hooks/useDispatch.spec.tsx
+++ b/test/hooks/useDispatch.spec.tsx
@@ -7,9 +7,10 @@ import {
   createDispatchHook,
 } from '../../src/index'
 import type { ProviderProps } from '../../src/'
+import type { ReactReduxContextValue } from '../../src/components/Context'
 
-const store = createStore((c: number): number => c + 1)
-const store2 = createStore((c: number): number => c + 2)
+const store = createStore((c: number = 1): number => c + 1)
+const store2 = createStore((c: number = 1): number => c + 2)
 
 describe('React', () => {
   describe('hooks', () => {
@@ -27,7 +28,8 @@ describe('React', () => {
     })
     describe('createDispatchHook', () => {
       it("returns the correct store's dispatch function", () => {
-        const nestedContext = React.createContext(null)
+        const nestedContext =
+          React.createContext<ReactReduxContextValue | null>(null)
         const useCustomDispatch = createDispatchHook(nestedContext)
         const { result } = renderHook(() => useDispatch(), {
           // eslint-disable-next-line react/prop-types

--- a/test/hooks/useSelector.spec.tsx
+++ b/test/hooks/useSelector.spec.tsx
@@ -57,7 +57,8 @@ describe('React', () => {
         })
 
         it('selects the state and renders the component when the store updates', () => {
-          const selector: jest.Mock<number, [s: NormalStateType]> = jest.fn(
+          type MockParams = [NormalStateType]
+          const selector: jest.Mock<number, MockParams> = jest.fn(
             (s) => s.count
           )
 

--- a/test/hooks/useSelector.spec.tsx
+++ b/test/hooks/useSelector.spec.tsx
@@ -57,8 +57,7 @@ describe('React', () => {
         })
 
         it('selects the state and renders the component when the store updates', () => {
-          type MockParams = [NormalStateType]
-          const selector: jest.Mock<number, MockParams> = jest.fn(
+          const selector: jest.Mock<number, [s: NormalStateType]> = jest.fn(
             (s) => s.count
           )
 

--- a/test/typetests/react-redux-types.typetest.tsx
+++ b/test/typetests/react-redux-types.typetest.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, no-inner-declarations */
 import { Component, ReactElement } from 'react'
-import * as React from 'react'
-import * as ReactDOM from 'react-dom'
+import React from 'react'
+import ReactDOM from 'react-dom'
 import { Store, Dispatch, bindActionCreators, AnyAction } from 'redux'
 import { connect, Provider, ConnectedProps } from '../../src/index'
 import { expectType } from '../typeTestHelpers'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "emitDeclarationOnly": true,
     "outDir": "./es",
     "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators":true
   },
   "include": ["src/**/*", "test/**/*", "types"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "./es",
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
   },
-  "include": ["src/**/*", "types"],
+  "include": ["src/**/*", "test/**/*", "types"],
   "exclude": ["node_modules", "dist"]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,16 +1,4 @@
 /* eslint-disable no-unused-vars */
-declare module 'react-dom' {
-  export function unstable_batchedUpdates<A, B>(
-    callback: (a: A, b: B) => any,
-    a: A,
-    b: B
-  ): void
-  export function unstable_batchedUpdates<A>(
-    callback: (a: A) => any,
-    a: A
-  ): void
-  export function unstable_batchedUpdates(callback: () => any): void
-}
 
 declare module 'react-native' {
   export function unstable_batchedUpdates<A, B>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3571,9 +3571,9 @@ __metadata:
   linkType: hard
 
 "@types/normalize-package-data@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@types/normalize-package-data@npm:2.4.0"
-  checksum: 6d077e73be7ac6227b678829c7bd765607136cdef537fd4ee7f368d9302a651aea924254d69826663322048436d90d6e7c679c9aa99c4824a687c568aab8ce4f
+  version: 2.4.1
+  resolution: "@types/normalize-package-data@npm:2.4.1"
+  checksum: d7bb5756003a5dbf3ea1ee24ee336c036f3670a7f1ca2c8c840b5ba8fdf4b7063f8d8df16ec0427f622cc97e1c44710f089720d7caa521a5f4ec6f4073c69261
   languageName: node
   linkType: hard
 
@@ -3599,9 +3599,9 @@ __metadata:
   linkType: hard
 
 "@types/prettier@npm:^2.0.0":
-  version: 2.3.1
-  resolution: "@types/prettier@npm:2.3.1"
-  checksum: 62ddbb1ba05d0df97fe49536e0d5409ea76d45cd2f6de062ff351d049e667b77010d2e912733d5d3255829fa1958c684a059e619f9d81e2ba9f27a6204a06149
+  version: 2.3.2
+  resolution: "@types/prettier@npm:2.3.2"
+  checksum: 7b425386aaf3b03fa63382ed1aceff367477ef9a52a2705978bfb1495fa1d8795316e1ab84671f6c8c5920de59a33d1567d837b9eb033996983efdfdbce84cb3
   languageName: node
   linkType: hard
 
@@ -5606,7 +5606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^3.0.0, ci-info@npm:^3.1.1":
+"ci-info@npm:^3.0.0":
   version: 3.2.0
   resolution: "ci-info@npm:3.2.0"
   checksum: d4a898d60111d00f2b7a06a349162971fe0603aefa208fe8d1343ce9e93c48e3d37311c47211d5c9040d25b43038c817588e5b7d8eab5d17b00aec49c7b5fade
@@ -9694,17 +9694,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-ci@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-ci@npm:3.0.0"
-  dependencies:
-    ci-info: ^3.1.1
-  bin:
-    is-ci: bin.js
-  checksum: 1e26d3ba6634ebee83f9d22f260354c5d950eada4d609c30cc2642069f8ba52f3aeb4c9bbf8099aaf04a2f44a1ed7beef2a24485f988753c8c078a57e9b3a2fd
-  languageName: node
-  linkType: hard
-
 "is-color-stop@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-color-stop@npm:1.1.0"
@@ -10711,7 +10700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^26.6.2":
+"jest-util@npm:^26.1.0, jest-util@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-util@npm:26.6.2"
   dependencies:
@@ -10722,20 +10711,6 @@ __metadata:
     is-ci: ^2.0.0
     micromatch: ^4.0.2
   checksum: 1aef748c8224d00ead3389899177bd3b619479db7318f8d7de7fbedce283ac6a8dc8c9364a40a68e83e68e03fa18afbd6b49c8aafb81112807872f0f90fb5a37
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^27.0.0":
-  version: 27.0.6
-  resolution: "jest-util@npm:27.0.6"
-  dependencies:
-    "@jest/types": ^27.0.6
-    "@types/node": "*"
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.4
-    is-ci: ^3.0.0
-    picomatch: ^2.2.3
-  checksum: a62ab3304ad58eb5fa130d66680d987890fca8c0505857a1b8bbcc8cf1de35eb3b82e19bdc5084dd10f68b3ce373234723f57f6e83781d4a4f66be1b647b488d
   languageName: node
   linkType: hard
 
@@ -14561,7 +14536,7 @@ __metadata:
     rimraf: ^3.0.2
     rollup: ^2.32.1
     rollup-plugin-terser: ^7.0.2
-    ts-jest: ^27.0.3
+    ts-jest: 26.5.6
     typescript: ^4.3.4
   peerDependencies:
     react: ^16.8.3 || ^17
@@ -16963,14 +16938,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^27.0.3":
-  version: 27.0.3
-  resolution: "ts-jest@npm:27.0.3"
+"ts-jest@npm:26.5.6":
+  version: 26.5.6
+  resolution: "ts-jest@npm:26.5.6"
   dependencies:
     bs-logger: 0.x
     buffer-from: 1.x
     fast-json-stable-stringify: 2.x
-    jest-util: ^27.0.0
+    jest-util: ^26.1.0
     json5: 2.x
     lodash: 4.x
     make-error: 1.x
@@ -16978,11 +16953,11 @@ __metadata:
     semver: 7.x
     yargs-parser: 20.x
   peerDependencies:
-    jest: ^27.0.0
+    jest: ">=26 <27"
     typescript: ">=3.8 <5.0"
   bin:
     ts-jest: cli.js
-  checksum: a63f3a8620a16335d745f22377a9cc118129d28a5b122c609a7c6aabbb8048c85733c771a0dd39b136e8a75401473409452bdd3c5b9e3b85317c2e3f3ac03267
+  checksum: fd32a8b256091d45d850c491fd090f74a368d44bccc8fedfa0dd074757727e7f07621eb2a69ebf081428f44a357a879237a2cf0aef970896410d454d0bf87ac6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14537,7 +14537,7 @@ __metadata:
     rollup: ^2.32.1
     rollup-plugin-terser: ^7.0.2
     ts-jest: 26.5.6
-    typescript: ^4.3.4
+    typescript: 3.9
   peerDependencies:
     react: ^16.8.3 || ^17
   peerDependenciesMeta:
@@ -17084,7 +17084,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.3.4, typescript@npm:~4.3.2":
+"typescript@npm:3.9":
+  version: 3.9.10
+  resolution: "typescript@npm:3.9.10"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 544f3810ac3d3fcd141907e7f52f0b8c70af178adc83af47e2b8a48351e5a119919a4d3bfbe2f62d5165b5aa203e896fe0432024cfbda670dbd03a4f53ce7748
+  languageName: node
+  linkType: hard
+
+"typescript@npm:~4.3.2":
   version: 4.3.5
   resolution: "typescript@npm:4.3.5"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14537,7 +14537,7 @@ __metadata:
     rollup: ^2.32.1
     rollup-plugin-terser: ^7.0.2
     ts-jest: 26.5.6
-    typescript: 3.9
+    typescript: ^4.3.4
   peerDependencies:
     react: ^16.8.3 || ^17
   peerDependenciesMeta:
@@ -17084,17 +17084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:3.9":
-  version: 3.9.10
-  resolution: "typescript@npm:3.9.10"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 544f3810ac3d3fcd141907e7f52f0b8c70af178adc83af47e2b8a48351e5a119919a4d3bfbe2f62d5165b5aa203e896fe0432024cfbda670dbd03a4f53ce7748
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~4.3.2":
+"typescript@npm:^4.3.4, typescript@npm:~4.3.2":
   version: 4.3.5
   resolution: "typescript@npm:4.3.5"
   bin:


### PR DESCRIPTION
I found some big problems:

- ts-jest does not check the converted type file, the previous configuration was problematic
  
- I have now fixed it, but due to the strict mode of tsconfig, there are some type errors that need to be reworked  :sob:

ref: #1737 
