### PR TITLE
Fixed Link bug

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -217,3 +217,6 @@ a:visited {
   stroke: black;
 }
 
+.admonition a {
+  color: #000;
+}


### PR DESCRIPTION
This adds rule to override default link behavior
Fixes #1782 

Screenshot :

Light Mode
![image](https://user-images.githubusercontent.com/55234838/127744089-85377c5c-eeaf-4aa9-9509-6106b7877270.png)

Dark Mode
![image](https://user-images.githubusercontent.com/55234838/127744106-3597a770-19a6-4614-86a3-551b385f24d7.png)


Consistent color is maintained in both modes