### PR TITLE
Fix connect.md

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -230,7 +230,7 @@ connect(mapStateToProps, mapDispatchToProps, null, { context: MyContext })(
 
 - default value: `true`
 
-Assumes that the wrapped component is a “pure” component and does not rely on any input or state other than its props and the selected Redux store’s state.
+Assumes that the wrapper component is a “pure” component and does not rely on any input or state other than its props and the selected Redux store’s state.
 
 When `options.pure` is true, `connect` performs several equality checks that are used to avoid unnecessary calls to `mapStateToProps`, `mapDispatchToProps`, `mergeProps`, and ultimately to `render`. These include `areStatesEqual`, `areOwnPropsEqual`, `areStatePropsEqual`, and `areMergedPropsEqual`. While the defaults are probably appropriate 99% of the time, you may wish to override them with custom implementations for performance or other reasons.
 


### PR DESCRIPTION
I read this line.  It seems that a wrapper component rely on its props and the selected Redux store’s state.
https://github.com/reduxjs/react-redux/blob/d4e4eba9ccbd488b103b3c5625a37e15b1427d11/src/components/connectAdvanced.tsx#L479

I think a wrapped component rely on its state.