### PR TITLE
"pure" component -> "pure" function in connect.md

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -230,7 +230,7 @@ connect(mapStateToProps, mapDispatchToProps, null, { context: MyContext })(
 
 - default value: `true`
 
-Assumes that the wrapped component is a “pure” component and does not rely on any input or state other than its props and the selected Redux store’s state.
+Assumes that the wrapper component is a “pure” function and does not rely on any input or state other than its props and the selected Redux store’s state.
 
 When `options.pure` is true, `connect` performs several equality checks that are used to avoid unnecessary calls to `mapStateToProps`, `mapDispatchToProps`, `mergeProps`, and ultimately to `render`. These include `areStatesEqual`, `areOwnPropsEqual`, `areStatePropsEqual`, and `areMergedPropsEqual`. While the defaults are probably appropriate 99% of the time, you may wish to override them with custom implementations for performance or other reasons.
 


### PR DESCRIPTION
Relationship between wrapper component and wrapped component `connect.md`.

```js
const WrapperComponent = connect(mapStateToProps, actionCreators)(WrappedComponent)
```

I read this lines.

https://github.com/reduxjs/react-redux/blob/d4e4eba9ccbd488b103b3c5625a37e15b1427d11/src/components/connectAdvanced.tsx#L277-L480

> Assumes that the wrapped component is a “pure” component and does not rely on any input or state other than its props and the selected Redux store’s state.

* [PureComponent](https://reactjs.org/docs/react-api.html#reactpurecomponent) rely on props and state. This is inconsistent with "does not rely on any input or state". Therefore, I think [pure function](https://en.wikipedia.org/wiki/Pure_function) is correct, not pure component.

* A wrapper component does not have its state. A wrapped component may have its state and may rely on its state. This is inconsistent with "does not rely on any input or state".  Therefore, I think wrapper component is correct, not wrapped component.