### PR TITLE
Fixed compatibility with React 18 strict effects

### DIFF
--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -22,7 +22,6 @@ export interface ProviderProps<A extends Action = AnyAction> {
 function Provider({ store, context, children }: ProviderProps) {
   const contextValue = useMemo(() => {
     const subscription = createSubscription(store)
-    subscription.onStateChange = subscription.notifyNestedSubs
     return {
       store,
       subscription,
@@ -33,6 +32,7 @@ function Provider({ store, context, children }: ProviderProps) {
 
   useIsomorphicLayoutEffect(() => {
     const { subscription } = contextValue
+    subscription.onStateChange = subscription.notifyNestedSubs
     subscription.trySubscribe()
 
     if (previousState !== store.getState()) {


### PR DESCRIPTION
Related to: https://github.com/reduxjs/react-redux/issues/1732#issuecomment-918697306

I could write a test for this but that would require me to target the [`feature/react-18-initial-compat`](https://github.com/reduxjs/react-redux/tree/feature/react-18-initial-compat) and I'm not sure if that's a good idea at this point.

Let me know if you want me to target some other branch or maybe if this is totally irrelevant for the time being. Note that I have not actually tested this with React 18 yet but, from a theoretical point of view, it should help with the investigated issue. I was just curious to see if there is any particular reason why the "symmetry" was not here so I've decided to run a test suite against a "symmetric" implementation to check out if there would be any failures. Since the test suite has passed - I've thought that it might be worth pushing this out.