### PR TITLE
Fix reducer typo

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -50,7 +50,7 @@ import { configureStore } from '@reduxjs/toolkit'
 // ...
 
 const store = configureStore({
-  reducer: {
+  reducers: {
     posts: postsReducer,
     comments: commentsReducer,
     users: usersReducer,


### PR DESCRIPTION
The object is supposed to be "reducers" not "reducer" in configureStore