### PR TITLE
chore: enable linter for tsx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "build": "yarn build:types && yarn build:commonjs && yarn build:es && yarn build:umd && yarn build:umd:min",
     "clean": "rimraf lib dist es coverage",
     "api-types": "api-extractor run --local",
-    "format": "prettier --write \"{src,test}/**/*.{js,ts}\" \"docs/**/*.md\"",
-    "lint": "eslint src --ext ts,js test/utils test/components test/hooks",
+    "format": "prettier --write \"{src,test}/**/*.{js,ts,tsx}\" \"docs/**/*.md\"",
+    "lint": "eslint src --ext ts,tsx,js test/utils test/components test/hooks",
     "prepare": "yarn clean && yarn build",
     "pretest": "yarn lint",
     "test": "jest",
@@ -56,7 +56,6 @@
     "@types/use-sync-external-store": "^0.0.0",
     "hoist-non-react-statics": "^3.3.2",
     "loose-envify": "^1.4.0",
-    "prop-types": "^15.7.2",
     "react-is": "^16.13.1",
     "use-sync-external-store": "0.0.0-experimental-7d38e4fd8-20210930"
   },

--- a/src/hooks/useDispatch.ts
+++ b/src/hooks/useDispatch.ts
@@ -1,4 +1,4 @@
-import { Action, ActionCreator, AnyAction, Dispatch, Store } from 'redux'
+import { Action, AnyAction, Dispatch } from 'redux'
 import { Context } from 'react'
 
 import {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,9 @@
 /* eslint-disable no-unused-vars */
 // TODO Ignoring all unused variables for now
 
-import {
-  ClassAttributes,
-  Component,
-  ComponentClass,
-  ComponentType,
-  StatelessComponent,
-  Context,
-  NamedExoticComponent,
-} from 'react'
+import { ClassAttributes, ComponentClass, ComponentType } from 'react'
 
-import { Action, ActionCreator, AnyAction, Dispatch, Store } from 'redux'
+import { Action, AnyAction, Dispatch } from 'redux'
 
 // import hoistNonReactStatics = require('hoist-non-react-statics');
 import type { NonReactStatics } from 'hoist-non-react-statics'

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -1,8 +1,7 @@
 /*eslint-disable react/prop-types*/
 
-import React, { Component, MouseEvent, useLayoutEffect } from 'react'
+import React, { Component, MouseEvent } from 'react'
 import createClass from 'create-react-class'
-import PropTypes from 'prop-types'
 import { createStore, applyMiddleware } from 'redux'
 import { Provider as ProviderMock, connect } from '../../src/index'
 import * as rtl from '@testing-library/react'

--- a/test/hooks/useSelector.spec.tsx
+++ b/test/hooks/useSelector.spec.tsx
@@ -10,14 +10,9 @@ import {
   connect,
   createSelectorHook,
 } from '../../src/index'
-import { useReduxContext } from '../../src/hooks/useReduxContext'
 import type { FunctionComponent, DispatchWithoutAction, ReactNode } from 'react'
 import type { Store, AnyAction } from 'redux'
-import type {
-  TypedUseSelectorHook,
-  ReactReduxContextValue,
-  Subscription,
-} from '../../src/'
+import type { TypedUseSelectorHook, ReactReduxContextValue } from '../../src/'
 
 describe('React', () => {
   describe('hooks', () => {
@@ -138,11 +133,7 @@ describe('React', () => {
               }
             })
 
-          let rootSubscription: Subscription
-
           const Parent = () => {
-            const { subscription } = useReduxContext() as ReactReduxContextValue
-            rootSubscription = subscription
             const count = useNormalSelector((s) => s.count)
             return count === 1 ? <Child /> : null
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9063,7 +9063,6 @@ __metadata:
     jest: ^26.6.1
     loose-envify: ^1.4.0
     prettier: ^2.1.2
-    prop-types: ^15.7.2
     react: 0.0.0-experimental-7d38e4fd8-20210930
     react-dom: 0.0.0-experimental-7d38e4fd8-20210930
     react-is: ^16.13.1


### PR DESCRIPTION
- Enabled linter for `.tsx` files
- Fixed linter errors
- Removed no longer used `prop-types` dependency

Related to https://github.com/reduxjs/react-redux/issues/1737