### PR TITLE
Simplify dependency caching in CI workflow and upgrade `setup-node`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,20 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
         with:
-          path: .yarn/cache
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
+          node-version: 14.x
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install
@@ -52,15 +46,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-
-      - uses: actions/cache@v2
-        with:
-          path: .yarn/cache
-          key: yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: yarn-
+          cache: 'yarn'
 
       - name: Install deps
         run: yarn install


### PR DESCRIPTION
This PR upgrades `actions/setup-node` from `v1` to `v2`. `v2` has dependency caching built into it, which has been added to this PR to simplify the CI workflow.

References:
* https://github.com/actions/setup-node#caching-packages-dependencies