### PR TITLE
⬆️ Bump Docusaurus to 2.0 beta 7

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,8 +9,8 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-beta.4",
-    "@docusaurus/preset-classic": "2.0.0-beta.4",
+    "@docusaurus/core": "2.0.0-beta.7",
+    "@docusaurus/preset-classic": "2.0.0-beta.7",
     "classnames": "^2.2.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -555,6 +555,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-async-generator-functions@npm:^7.15.8":
+  version: 7.15.8
+  resolution: "@babel/plugin-proposal-async-generator-functions@npm:7.15.8"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-remap-async-to-generator": ^7.15.4
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 70c66a9f926954a60e8a1649854408d795474f63e0030d98a07a3c7ce9d17ea204fb6bfe30251b7ef15212ddcca0325c1b167af7af8fc4225184e5f269c3ba55
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-class-properties@npm:^7.14.5":
   version: 7.14.5
   resolution: "@babel/plugin-proposal-class-properties@npm:7.14.5"
@@ -1287,19 +1300,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.12.15":
-  version: 7.15.0
-  resolution: "@babel/plugin-transform-runtime@npm:7.15.0"
+"@babel/plugin-transform-runtime@npm:^7.15.0":
+  version: 7.15.8
+  resolution: "@babel/plugin-transform-runtime@npm:7.15.8"
   dependencies:
-    "@babel/helper-module-imports": ^7.14.5
+    "@babel/helper-module-imports": ^7.15.4
     "@babel/helper-plugin-utils": ^7.14.5
     babel-plugin-polyfill-corejs2: ^0.2.2
-    babel-plugin-polyfill-corejs3: ^0.2.2
+    babel-plugin-polyfill-corejs3: ^0.2.5
     babel-plugin-polyfill-regenerator: ^0.2.2
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 159c3a02e24cabc67e121e22d6446e72af47c3ae94d10851fb30facdf62f920f735302273ff4b8df565a633c47d44d20a85eb290717635d4ec4c4fa48fdfd9f4
+  checksum: 60255e05bba0b77cf663c549ed09cddefdcdfaf2f5d462cf0c06cfe73f21874819613cab0a7b15ac4ed4f7dece1707799a27cb0c233891570663fca74ade7f40
   languageName: node
   linkType: hard
 
@@ -1323,6 +1336,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9511fd90a53a2537f209e9165ad7efc28fc50985bedf5fc6fedb5a2acaab3f3e3bb8c8ad6247c0ec164d2e96e9b8afcd3dd8c20310459081cb5ae3f0ba246e56
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-spread@npm:^7.15.8":
+  version: 7.15.8
+  resolution: "@babel/plugin-transform-spread@npm:7.15.8"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.15.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 751b5e2a90b1f837d33dd18660274b4d968ce9f76fb3fee68c6199c38d120c599a9f2a9d859cdbd5f0b22089b78939db7f2b252d773f43b62963a16cdfffe2f5
   languageName: node
   linkType: hard
 
@@ -1395,7 +1420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.12.1, @babel/preset-env@npm:^7.12.16":
+"@babel/preset-env@npm:^7.12.1":
   version: 7.15.6
   resolution: "@babel/preset-env@npm:7.15.6"
   dependencies:
@@ -1478,6 +1503,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-env@npm:^7.15.6":
+  version: 7.15.8
+  resolution: "@babel/preset-env@npm:7.15.8"
+  dependencies:
+    "@babel/compat-data": ^7.15.0
+    "@babel/helper-compilation-targets": ^7.15.4
+    "@babel/helper-plugin-utils": ^7.14.5
+    "@babel/helper-validator-option": ^7.14.5
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.15.4
+    "@babel/plugin-proposal-async-generator-functions": ^7.15.8
+    "@babel/plugin-proposal-class-properties": ^7.14.5
+    "@babel/plugin-proposal-class-static-block": ^7.15.4
+    "@babel/plugin-proposal-dynamic-import": ^7.14.5
+    "@babel/plugin-proposal-export-namespace-from": ^7.14.5
+    "@babel/plugin-proposal-json-strings": ^7.14.5
+    "@babel/plugin-proposal-logical-assignment-operators": ^7.14.5
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.14.5
+    "@babel/plugin-proposal-numeric-separator": ^7.14.5
+    "@babel/plugin-proposal-object-rest-spread": ^7.15.6
+    "@babel/plugin-proposal-optional-catch-binding": ^7.14.5
+    "@babel/plugin-proposal-optional-chaining": ^7.14.5
+    "@babel/plugin-proposal-private-methods": ^7.14.5
+    "@babel/plugin-proposal-private-property-in-object": ^7.15.4
+    "@babel/plugin-proposal-unicode-property-regex": ^7.14.5
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+    "@babel/plugin-syntax-class-properties": ^7.12.13
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+    "@babel/plugin-syntax-top-level-await": ^7.14.5
+    "@babel/plugin-transform-arrow-functions": ^7.14.5
+    "@babel/plugin-transform-async-to-generator": ^7.14.5
+    "@babel/plugin-transform-block-scoped-functions": ^7.14.5
+    "@babel/plugin-transform-block-scoping": ^7.15.3
+    "@babel/plugin-transform-classes": ^7.15.4
+    "@babel/plugin-transform-computed-properties": ^7.14.5
+    "@babel/plugin-transform-destructuring": ^7.14.7
+    "@babel/plugin-transform-dotall-regex": ^7.14.5
+    "@babel/plugin-transform-duplicate-keys": ^7.14.5
+    "@babel/plugin-transform-exponentiation-operator": ^7.14.5
+    "@babel/plugin-transform-for-of": ^7.15.4
+    "@babel/plugin-transform-function-name": ^7.14.5
+    "@babel/plugin-transform-literals": ^7.14.5
+    "@babel/plugin-transform-member-expression-literals": ^7.14.5
+    "@babel/plugin-transform-modules-amd": ^7.14.5
+    "@babel/plugin-transform-modules-commonjs": ^7.15.4
+    "@babel/plugin-transform-modules-systemjs": ^7.15.4
+    "@babel/plugin-transform-modules-umd": ^7.14.5
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.14.9
+    "@babel/plugin-transform-new-target": ^7.14.5
+    "@babel/plugin-transform-object-super": ^7.14.5
+    "@babel/plugin-transform-parameters": ^7.15.4
+    "@babel/plugin-transform-property-literals": ^7.14.5
+    "@babel/plugin-transform-regenerator": ^7.14.5
+    "@babel/plugin-transform-reserved-words": ^7.14.5
+    "@babel/plugin-transform-shorthand-properties": ^7.14.5
+    "@babel/plugin-transform-spread": ^7.15.8
+    "@babel/plugin-transform-sticky-regex": ^7.14.5
+    "@babel/plugin-transform-template-literals": ^7.14.5
+    "@babel/plugin-transform-typeof-symbol": ^7.14.5
+    "@babel/plugin-transform-unicode-escapes": ^7.14.5
+    "@babel/plugin-transform-unicode-regex": ^7.14.5
+    "@babel/preset-modules": ^0.1.4
+    "@babel/types": ^7.15.6
+    babel-plugin-polyfill-corejs2: ^0.2.2
+    babel-plugin-polyfill-corejs3: ^0.2.5
+    babel-plugin-polyfill-regenerator: ^0.2.2
+    core-js-compat: ^3.16.0
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3b3ed9c38512f17faae42f68d377c1486d5fdf7d6a968886a2df574d17cfa07223d51d9afb6d7a276cc7db76367415af217a6a1cedbd86da6ce116df1384fd7e
+  languageName: node
+  linkType: hard
+
 "@babel/preset-modules@npm:^0.1.4":
   version: 0.1.4
   resolution: "@babel/preset-modules@npm:0.1.4"
@@ -1522,7 +1630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.12.13":
+"@babel/runtime-corejs3@npm:^7.15.4":
   version: 7.15.4
   resolution: "@babel/runtime-corejs3@npm:7.15.4"
   dependencies:
@@ -1532,7 +1640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.8.4":
   version: 7.15.4
   resolution: "@babel/runtime@npm:7.15.4"
   dependencies:
@@ -1602,51 +1710,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/core@npm:2.0.0-beta.4"
+"@docusaurus/core@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/core@npm:2.0.0-beta.7"
   dependencies:
     "@babel/core": ^7.12.16
     "@babel/generator": ^7.12.15
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-runtime": ^7.12.15
-    "@babel/preset-env": ^7.12.16
+    "@babel/plugin-transform-runtime": ^7.15.0
+    "@babel/preset-env": ^7.15.6
     "@babel/preset-react": ^7.12.13
     "@babel/preset-typescript": ^7.12.16
-    "@babel/runtime": ^7.12.5
-    "@babel/runtime-corejs3": ^7.12.13
+    "@babel/runtime": ^7.15.4
+    "@babel/runtime-corejs3": ^7.15.4
     "@babel/traverse": ^7.12.13
-    "@docusaurus/cssnano-preset": 2.0.0-beta.4
+    "@docusaurus/cssnano-preset": 2.0.0-beta.7
     "@docusaurus/react-loadable": 5.5.0
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-common": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-common": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     "@slorber/static-site-generator-webpack-plugin": ^4.0.0
     "@svgr/webpack": ^5.5.0
-    autoprefixer: ^10.2.5
+    autoprefixer: ^10.3.5
     babel-loader: ^8.2.2
     babel-plugin-dynamic-import-node: 2.3.0
     boxen: ^5.0.1
-    chalk: ^4.1.1
-    chokidar: ^3.5.1
-    clean-css: ^5.1.2
+    chalk: ^4.1.2
+    chokidar: ^3.5.2
+    clean-css: ^5.1.5
     commander: ^5.1.0
-    copy-webpack-plugin: ^9.0.0
-    core-js: ^3.9.1
+    copy-webpack-plugin: ^9.0.1
+    core-js: ^3.18.0
     css-loader: ^5.1.1
-    css-minimizer-webpack-plugin: ^3.0.1
-    cssnano: ^5.0.4
+    css-minimizer-webpack-plugin: ^3.0.2
+    cssnano: ^5.0.8
     del: ^6.0.0
     detect-port: ^1.3.0
     escape-html: ^1.0.3
-    eta: ^1.12.1
+    eta: ^1.12.3
     express: ^4.17.1
     file-loader: ^6.2.0
     fs-extra: ^10.0.0
-    github-slugger: ^1.3.0
+    github-slugger: ^1.4.0
     globby: ^11.0.2
-    html-minifier-terser: ^5.1.1
+    html-minifier-terser: ^6.0.2
     html-tags: ^3.1.0
     html-webpack-plugin: ^5.3.2
     import-fresh: ^3.3.0
@@ -1656,8 +1764,8 @@ __metadata:
     mini-css-extract-plugin: ^1.6.0
     module-alias: ^2.2.2
     nprogress: ^0.2.0
-    postcss: ^8.2.15
-    postcss-loader: ^5.3.0
+    postcss: ^8.3.7
+    postcss-loader: ^6.1.1
     prompts: ^2.4.1
     react-dev-utils: ^11.0.1
     react-error-overlay: ^6.0.9
@@ -1667,18 +1775,19 @@ __metadata:
     react-router: ^5.2.0
     react-router-config: ^5.1.1
     react-router-dom: ^5.2.0
+    remark-admonitions: ^1.2.1
     resolve-pathname: ^3.0.0
-    rtl-detect: ^1.0.3
+    rtl-detect: ^1.0.4
     semver: ^7.3.4
     serve-handler: ^6.1.3
     shelljs: ^0.8.4
     std-env: ^2.2.1
     strip-ansi: ^6.0.0
-    terser-webpack-plugin: ^5.1.3
-    tslib: ^2.2.0
+    terser-webpack-plugin: ^5.2.4
+    tslib: ^2.3.1
     update-notifier: ^5.1.0
     url-loader: ^4.1.1
-    wait-on: ^5.3.0
+    wait-on: ^6.0.0
     webpack: ^5.40.0
     webpack-bundle-analyzer: ^4.4.2
     webpack-dev-server: ^3.11.2
@@ -1689,36 +1798,36 @@ __metadata:
     react-dom: ^16.8.4 || ^17.0.0
   bin:
     docusaurus: bin/docusaurus.js
-  checksum: 2ddbd07c3849b267f00780e373d137f624f5cc69ad20474cbd0ea53b7a3e8ce903917fe66a3c9bf58f3f6f4d6d7c6d9ab93f4f6dc12e4b72ff3872cee07d939b
+  checksum: 0a66946edbd5fc0335221d07043898413d0b09ad5016562e0fcd1663025ee804627e56576c3a40fdb3c64006c3467805019fc2dbe3783e397b80aa96b5fff3b2
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.4"
+"@docusaurus/cssnano-preset@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/cssnano-preset@npm:2.0.0-beta.7"
   dependencies:
-    cssnano-preset-advanced: ^5.1.1
-    postcss: ^8.2.15
-    postcss-sort-media-queries: ^3.10.11
-  checksum: aa9f222f97aaab93bdd038cad9eacb101a448c515d5779f10f44b16be04ec7d674ee6ce2c9ecdfc14a7ef95d807e2656bb11d80a33937ae77ef2253b5653f3bc
+    cssnano-preset-advanced: ^5.1.4
+    postcss: ^8.3.7
+    postcss-sort-media-queries: ^4.1.0
+  checksum: 16404ad7633777fe55b0188353f9a16aefda9065c1c219b0274c1d7359006049530bfbef6388b432efac91cdcd8a4245a045d79a9a9b1c355a26e63dc605e5ec
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.4"
+"@docusaurus/mdx-loader@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/mdx-loader@npm:2.0.0-beta.7"
   dependencies:
     "@babel/parser": ^7.12.16
     "@babel/traverse": ^7.12.13
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.1
+    chalk: ^4.1.2
     escape-html: ^1.0.3
     file-loader: ^6.2.0
     fs-extra: ^10.0.0
-    github-slugger: ^1.3.0
+    github-slugger: ^1.4.0
     gray-matter: ^4.0.3
     mdast-util-to-string: ^2.0.0
     remark-emoji: ^2.1.0
@@ -1729,47 +1838,49 @@ __metadata:
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 74b221483ddbe9c3028f38cd182aa909bdbe59eafb524a53286d9fd7b53ddacef4aa9e98cfa570dbc8a10b378f29a2d18774d440969adfcecbc6055cf7639b85
+  checksum: 222cda9caacf9d4449a74e5259823539e74461ffc9efdf08dea541b82ff4e5680c09310413d5d5a272004d8ca42edb0fb7d7aaf9ae575602538b9c032905535b
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.4"
+"@docusaurus/plugin-content-blog@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-content-blog@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/mdx-loader": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
-    chalk: ^4.1.1
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/mdx-loader": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
+    chalk: ^4.1.2
     escape-string-regexp: ^4.0.0
     feed: ^4.2.2
     fs-extra: ^10.0.0
     globby: ^11.0.2
+    js-yaml: ^4.0.0
     loader-utils: ^2.0.0
     lodash: ^4.17.20
-    reading-time: ^1.3.0
+    reading-time: ^1.5.0
     remark-admonitions: ^1.2.1
-    tslib: ^2.2.0
+    tslib: ^2.3.1
+    utility-types: ^3.10.0
     webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 84a07b115844cd6995b043b79d0ffbdf0a2a3d8c762c4764709a65ab12205b9f8419d74eb0249d5f818efb49a39180022e77cb6e2a1936d009b3b3dc32e2c637
+  checksum: c771af740a730a7e5fa353c5e5cf58b06e0c4f1085d35c718479bdd30da74f53b8925a7d6571b1205a99e5fd43f817a58782b0a4cea4988d78a66a058fb39cc8
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.4"
+"@docusaurus/plugin-content-docs@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-content-docs@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/mdx-loader": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
-    chalk: ^4.1.1
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/mdx-loader": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
+    chalk: ^4.1.2
     combine-promises: ^1.1.0
     escape-string-regexp: ^4.0.0
     execa: ^5.0.0
@@ -1777,118 +1888,119 @@ __metadata:
     globby: ^11.0.2
     import-fresh: ^3.2.2
     js-yaml: ^4.0.0
-    loader-utils: ^1.2.3
+    loader-utils: ^2.0.0
     lodash: ^4.17.20
     remark-admonitions: ^1.2.1
     shelljs: ^0.8.4
-    tslib: ^2.2.0
+    tslib: ^2.3.1
     utility-types: ^3.10.0
     webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: a633d1062f57c4ef153595bf9b7ca997682e4bb3a04f48e677e1ae76052189b9bcb40388ded1923cfcf74b97d5fd4fe16de59f249c13eab1534ac8b6912112e1
+  checksum: 457f7cfe2f812b00531bef6b50c22fa0cf0a3d30b392b853475491dccfc52b9c2b85f7419db9c34f38141c0edf3442bd457b9259300285abd244cf31bfcfddef
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.4"
+"@docusaurus/plugin-content-pages@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-content-pages@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/mdx-loader": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/mdx-loader": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     globby: ^11.0.2
     lodash: ^4.17.20
     remark-admonitions: ^1.2.1
-    tslib: ^2.1.0
+    tslib: ^2.3.1
     webpack: ^5.40.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 25f3059f2101ad380d25cf3b1dee4fc054e0533f1de1a22b381f3570dbde2f7452b51ef5c4135b52e5f676bb61a46417ef6e239ac188f80c27e0ad1fa8ff0c08
+  checksum: 8e720fbf61cb02b089cec7accb17c761b91c7420cbe667f3f9260b69b9e75f9d06a01b5a91f423efb729783d53f887a7146e3c34f5642040eade41643c2a2dd2
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.4"
+"@docusaurus/plugin-debug@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-debug@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    fs-extra: ^10.0.0
     react-json-view: ^1.21.3
-    tslib: ^2.1.0
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 23b25d0c57c0551ddde44eba7949face94a3178d937d154dc58842f9fb864cb93d9b6d931321f23c89b85bee9bc87983e6574ffe5e0f24f75796c60d27b5edf4
+  checksum: cdf8265f7917c09f36fcb6548c286543f0033595e6947b6e84f8df5655bd274638b1bba419e648ac0e324a0c44de7214db1aa83db5835207d8cf4867491879de
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.4"
+"@docusaurus/plugin-google-analytics@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-google-analytics@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 725dd8f05e9e6787cfdfd37a3ad1e487874bd8f1ad2fdc9e285cbf54f3df15d04f46c587c71e8029bb0e92f73da058d29ba8630611db23d11fc43b8f2c617d58
+  checksum: bb11a4f57084a4bb811926f13dbf9ad571b08e9faed1cc256512d70c3e201825aa6019ba85a24d00e97f679f8cf5b3082d4ebd59f6e12db7c65352fa55f769e4
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.4"
+"@docusaurus/plugin-google-gtag@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-google-gtag@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: f84c583c8784265bb135f2de605fdc624ae33227a001322e81b9a749d046c69fffef444f9fa86aad2d7986f8ced175238b7d96dc8b8408f515f941d3fad9b82f
+  checksum: 9b12675f9cc553867bf1c44e159a97fb20c7b89ea08e8880455a3903c9806d8ef7e8c34e87cade962591620f639012ce3a6d45854273d29720427cf1aa96d43a
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.4"
+"@docusaurus/plugin-sitemap@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/plugin-sitemap@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-common": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-common": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     fs-extra: ^10.0.0
     sitemap: ^7.0.0
-    tslib: ^2.2.0
+    tslib: ^2.3.1
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 3bcc3e2311f9b645a5861839c63fe4cb2090d30f8ce8d1c1b4d7678ce9e794c9c4e633462d4bec560a2eb9ec26e9bb625bc4fa8609b3424817f9a8ffcb618ccb
+  checksum: 890b5b22551a0866b77a97c9ba8aa1dbe01d048bbca6c598c85274dacb8e10e5ea627d50fc6244a1afd029731645fb17bbef3116528db14945642f9024b9f646
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.4"
+"@docusaurus/preset-classic@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/preset-classic@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.4
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.4
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.4
-    "@docusaurus/plugin-debug": 2.0.0-beta.4
-    "@docusaurus/plugin-google-analytics": 2.0.0-beta.4
-    "@docusaurus/plugin-google-gtag": 2.0.0-beta.4
-    "@docusaurus/plugin-sitemap": 2.0.0-beta.4
-    "@docusaurus/theme-classic": 2.0.0-beta.4
-    "@docusaurus/theme-search-algolia": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.7
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.7
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.7
+    "@docusaurus/plugin-debug": 2.0.0-beta.7
+    "@docusaurus/plugin-google-analytics": 2.0.0-beta.7
+    "@docusaurus/plugin-google-gtag": 2.0.0-beta.7
+    "@docusaurus/plugin-sitemap": 2.0.0-beta.7
+    "@docusaurus/theme-classic": 2.0.0-beta.7
+    "@docusaurus/theme-search-algolia": 2.0.0-beta.7
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: ab96fb4e06de3eb909a2cb8669729f2e5bbe4b2bf0171d8a78cfc153632612a513d7223fb8b8ca12b10b560f0b9e83171fd9a98515b724131ba375944a05d6b5
+  checksum: 2603a7a07809918c45103d987c32bc192e1fd04ba8ce4c3f16124bc6824f8aee6f5246186b623245fc2d48adbd5d32e3feb8b549d78efc50a390198e60802275
   languageName: node
   linkType: hard
 
@@ -1903,134 +2015,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.4"
+"@docusaurus/theme-classic@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/theme-classic@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.4
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.4
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.4
-    "@docusaurus/theme-common": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-common": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.7
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.7
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.7
+    "@docusaurus/theme-common": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-common": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
     "@mdx-js/mdx": ^1.6.21
     "@mdx-js/react": ^1.6.21
-    chalk: ^4.1.1
+    chalk: ^4.1.2
     clsx: ^1.1.1
     copy-text-to-clipboard: ^3.0.1
     fs-extra: ^10.0.0
     globby: ^11.0.2
-    infima: 0.2.0-alpha.29
+    infima: 0.2.0-alpha.34
     lodash: ^4.17.20
-    parse-numeric-range: ^1.2.0
-    postcss: ^8.2.15
+    parse-numeric-range: ^1.3.0
+    postcss: ^8.3.7
     prism-react-renderer: ^1.2.1
     prismjs: ^1.23.0
     prop-types: ^15.7.2
     react-router-dom: ^5.2.0
-    rtlcss: ^3.1.2
+    rtlcss: ^3.3.0
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: c4c8b37ea8ad7abd69ee282348a9443b5cd5791aac2bf3ccaf1310a10bb4a5ca3302ace7a37e448113de04bc46b3caaeef303a4f72dfcadb7b58fcdcbcdb2ad2
+  checksum: 38e043b8a42aa6634cd87ed260ceee222d7852fa688210232f1d908feec119794ac67b4e324c9d89b71ec28c3ef15b20621458177fa0e52c29e509f5229dbc03
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.4"
+"@docusaurus/theme-common@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/theme-common@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/plugin-content-blog": 2.0.0-beta.4
-    "@docusaurus/plugin-content-docs": 2.0.0-beta.4
-    "@docusaurus/plugin-content-pages": 2.0.0-beta.4
-    "@docusaurus/types": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/plugin-content-blog": 2.0.0-beta.7
+    "@docusaurus/plugin-content-docs": 2.0.0-beta.7
+    "@docusaurus/plugin-content-pages": 2.0.0-beta.7
+    "@docusaurus/types": 2.0.0-beta.7
     clsx: ^1.1.1
     fs-extra: ^10.0.0
-    tslib: ^2.1.0
+    tslib: ^2.3.1
+    utility-types: ^3.10.0
   peerDependencies:
     prism-react-renderer: ^1.2.1
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 89a062c00d589ed78904027e41cd9e0578faf1cb8d269749fc926cb5e2ee72ef29ee2d728f8bbcbe5928b8303fd7ce263fda3b6a289f35bb9170206f0eddd99a
+  checksum: 64a22ed88ab44e179c743cc7e2d6e9ca199f3d61b2d211fc8f133e50daf4a88ecacc17803ade730e82be2aaf873d3f55833e933e26f0a27f6bc0399389de0e3a
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.4"
+"@docusaurus/theme-search-algolia@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/theme-search-algolia@npm:2.0.0-beta.7"
   dependencies:
     "@docsearch/react": ^3.0.0-alpha.39
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/theme-common": 2.0.0-beta.4
-    "@docusaurus/utils": 2.0.0-beta.4
-    "@docusaurus/utils-validation": 2.0.0-beta.4
-    algoliasearch: ^4.8.4
-    algoliasearch-helper: ^3.3.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/theme-common": 2.0.0-beta.7
+    "@docusaurus/utils": 2.0.0-beta.7
+    "@docusaurus/utils-validation": 2.0.0-beta.7
+    algoliasearch: ^4.10.5
+    algoliasearch-helper: ^3.5.5
     clsx: ^1.1.1
-    eta: ^1.12.1
+    eta: ^1.12.3
     lodash: ^4.17.20
   peerDependencies:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
-  checksum: 3e2160c700a0aa2f2d8cbef3342799f3e3fdbcf5322167e47b1aeb7bca98c024117e3eb9aa6ba73b7e0e56893b6f2db80877a465d336c44ba1009f1c173a05c8
+  checksum: 8df515cedeff3ceeeb8bc0bfc35d0b74313539b0c317209faecb42717f5b944713435ef1e39e879ed258f2e97d9d7a41a926ecac223d84cb02e37c7b8b8c2305
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/types@npm:2.0.0-beta.4"
+"@docusaurus/types@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/types@npm:2.0.0-beta.7"
   dependencies:
     commander: ^5.1.0
-    joi: ^17.4.0
+    joi: ^17.4.2
     querystring: 0.2.0
+    utility-types: ^3.10.0
     webpack: ^5.40.0
     webpack-merge: ^5.8.0
-  checksum: ba4ea7aef74bec0abcaf087b31a643a0d509faa8b7da698bb436e6184f94393afb886b99591dea5f9bdecc5f6ea226e5666736bb0f4fec0b32c666bc572d459a
+  checksum: a05f663c77ddc0613a2a4f1e2000dc54b2c4d773c573e3edd474d2877c2731f26cc2a64314863243429edf477dce21abe516e7d86dda2e07f26e361520cd087d
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.4"
+"@docusaurus/utils-common@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/utils-common@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.4
-    tslib: ^2.2.0
-  checksum: cf8da7993e2b9a12935f63e15785c921b007250d5c3f7e015593c95451e4ddc0d43f7d7696684b9c9e5c001e16f4ce77aff62daafd1b6b9305fab6b6c23e3abf
+    "@docusaurus/types": 2.0.0-beta.7
+    tslib: ^2.3.1
+  checksum: 173fdf856ed7a611fa9292bd673340081c30d33767d57d09fc4860f9028333f1103154c09d4df99f2833f2b8bcce1f331893355edbdc1f95187752504cb143c4
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.4"
+"@docusaurus/utils-validation@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/utils-validation@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/utils": 2.0.0-beta.4
-    chalk: ^4.1.1
-    joi: ^17.4.0
-    tslib: ^2.1.0
-  checksum: b9a6594dcace4f260e9e8012eeb99b6bdd84519ef46bd613951d077a6b8da67f7da3b223e3f9668b6a8f35c4ba8b7512f03ba02aa6d43befdec02c9abab1bdd9
+    "@docusaurus/utils": 2.0.0-beta.7
+    chalk: ^4.1.2
+    joi: ^17.4.2
+    tslib: ^2.3.1
+  checksum: 78eb56055913130cd3fde696adcf008711b7d8a7eb9f53ae8bb610130167c95330e169966026ea38204e9bce36f0f82d5e56a4098fd77431c0386540115952aa
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:2.0.0-beta.4":
-  version: 2.0.0-beta.4
-  resolution: "@docusaurus/utils@npm:2.0.0-beta.4"
+"@docusaurus/utils@npm:2.0.0-beta.7":
+  version: 2.0.0-beta.7
+  resolution: "@docusaurus/utils@npm:2.0.0-beta.7"
   dependencies:
-    "@docusaurus/types": 2.0.0-beta.4
+    "@docusaurus/types": 2.0.0-beta.7
+    "@mdx-js/runtime": ^1.6.22
     "@types/github-slugger": ^1.3.0
-    chalk: ^4.1.1
+    chalk: ^4.1.2
     escape-string-regexp: ^4.0.0
     fs-extra: ^10.0.0
     globby: ^11.0.4
     gray-matter: ^4.0.3
     lodash: ^4.17.20
     micromatch: ^4.0.4
+    remark-mdx-remove-exports: ^1.6.22
+    remark-mdx-remove-imports: ^1.6.22
     resolve-pathname: ^3.0.0
-    tslib: ^2.2.0
-  checksum: 5d687aa6ded085fa042e7d20042e5e74e0b6eabb9a8b94fbecf85d5360bc5868d7e1f2f1034b21803f1f126acc1a12fd217d6d06a5f5f5aad0f85d5cb3497362
+    tslib: ^2.3.1
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: f19f538f9ac764a334b5d06cab3ed0c02bc19a2406c75a9e182bed9ea3b4c764abeb5661941799a9c618eac58f67748024e1c03363ea88b35c56e015cac96d37
   languageName: node
   linkType: hard
 
@@ -2057,7 +2177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/mdx@npm:^1.6.21":
+"@mdx-js/mdx@npm:1.6.22, @mdx-js/mdx@npm:^1.6.21":
   version: 1.6.22
   resolution: "@mdx-js/mdx@npm:1.6.22"
   dependencies:
@@ -2084,12 +2204,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdx-js/react@npm:^1.6.21":
+"@mdx-js/react@npm:1.6.22, @mdx-js/react@npm:^1.6.21":
   version: 1.6.22
   resolution: "@mdx-js/react@npm:1.6.22"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
   checksum: 3a0a189aa04a3b73e4846f8311573d45404c4ec74a1a4b196e7829492fedabe38b869016125620403bcf5f999f58ab75c9f54279f7557e361c239b57e5ed2267
+  languageName: node
+  linkType: hard
+
+"@mdx-js/runtime@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "@mdx-js/runtime@npm:1.6.22"
+  dependencies:
+    "@mdx-js/mdx": 1.6.22
+    "@mdx-js/react": 1.6.22
+    buble-jsx-only: ^0.19.8
+  peerDependencies:
+    react: ^16.13.1
+  checksum: c66910c1bbdd23eb11416fb7b50020c1c0227a3855f6261aa427fce06c736de111e0ff183e05d7f7e498c86fdbf9e552072a9ac6dfc2e112c0a4b2eca196b651
   languageName: node
   linkType: hard
 
@@ -2667,6 +2800,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-dynamic-import@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "acorn-dynamic-import@npm:4.0.0"
+  peerDependencies:
+    acorn: ^6.0.0
+  checksum: ce61df77522b5eaee93f4a61043af9b059590d382bdbf5bf4a3717416d0cfb7bebbacb736d82764ba51381d2d55db4b27477384bb7e2642283941b52bcd9d008
+  languageName: node
+  linkType: hard
+
 "acorn-import-assertions@npm:^1.7.6":
   version: 1.7.6
   resolution: "acorn-import-assertions@npm:1.7.6"
@@ -2676,10 +2818,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-jsx@npm:^5.0.1":
+  version: 5.3.2
+  resolution: "acorn-jsx@npm:5.3.2"
+  peerDependencies:
+    acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 41c748fd26345f63fd27508c61596ffba5c4f23a8c98fffd2e75cf650c3928bb35af8658bf40d1ed18e56630cc9f4aa34d82bd5a3f53476df27d768eb03e9281
+  languageName: node
+  linkType: hard
+
 "acorn-walk@npm:^8.0.0":
   version: 8.2.0
   resolution: "acorn-walk@npm:8.2.0"
   checksum: 93ffbdb8b35dda04313f1d6a94bdfdf8f929337f742e3a6d51b3026ced8471feb6a522646240809da44b0f576f4902ff2fa0c64292b3216478992aefcbde3278
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^6.1.1":
+  version: 6.4.2
+  resolution: "acorn@npm:6.4.2"
+  bin:
+    acorn: bin/acorn
+  checksum: ec4707ffa0f41dcd9ef67e5f0938a9e8c83f2f1ffcbd3588b07126833d2ca3a6573e094c511162ad40f658a267c6533c6dd5eedead6844d50f7d8d0be080cc55
   languageName: node
   linkType: hard
 
@@ -2759,18 +2919,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"algoliasearch-helper@npm:^3.3.4":
-  version: 3.5.5
-  resolution: "algoliasearch-helper@npm:3.5.5"
+"algoliasearch-helper@npm:^3.5.5":
+  version: 3.6.1
+  resolution: "algoliasearch-helper@npm:3.6.1"
   dependencies:
     events: ^1.1.1
   peerDependencies:
     algoliasearch: ">= 3.1 < 5"
-  checksum: 1eefe77444942e717c7e450e3fd9e97770fa25d4a34748d11a344585ddb033961e0e0bcd4ee3ea336e41bc39195e0c55e3a679f23838e173bbe773d077010f8e
+  checksum: 378f1e9edd3ff99ab78c4afd40d36d5eb3508150d9997601c158cb0868eedb26fce9d6edb7dbce2da8eda2b44e1578b5300caf763607b50dd6c9d621ec58a781
   languageName: node
   linkType: hard
 
-"algoliasearch@npm:^4.0.0, algoliasearch@npm:^4.8.4":
+"algoliasearch@npm:^4.0.0, algoliasearch@npm:^4.10.5":
   version: 4.10.5
   resolution: "algoliasearch@npm:4.10.5"
   dependencies:
@@ -3050,7 +3210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.2.0, autoprefixer@npm:^10.2.5":
+"autoprefixer@npm:^10.2.0":
   version: 10.3.6
   resolution: "autoprefixer@npm:10.3.6"
   dependencies:
@@ -3065,6 +3225,24 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: 2e1b990592a6f982dfc2311a7c58494080b783ab45531277eed14949994c91704c25c596251fc0967dd2749a0cb6459a110781f724805f3c576dde4d3aa886d2
+  languageName: node
+  linkType: hard
+
+"autoprefixer@npm:^10.3.5":
+  version: 10.3.7
+  resolution: "autoprefixer@npm:10.3.7"
+  dependencies:
+    browserslist: ^4.17.3
+    caniuse-lite: ^1.0.30001264
+    fraction.js: ^4.1.1
+    normalize-range: ^0.1.2
+    picocolors: ^0.2.1
+    postcss-value-parser: ^4.1.0
+  peerDependencies:
+    postcss: ^8.1.0
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: bbd835343f14de4aaa9246d2196374eaafa59f2f9de3070ac4f9d7c5a92901b8fd6d03b5b0b33ed2b33c971946a010a69dc3703005456774ced5d98bb0e275e0
   languageName: node
   linkType: hard
 
@@ -3144,7 +3322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs3@npm:^0.2.2":
+"babel-plugin-polyfill-corejs3@npm:^0.2.2, babel-plugin-polyfill-corejs3@npm:^0.2.5":
   version: 0.2.5
   resolution: "babel-plugin-polyfill-corejs3@npm:0.2.5"
   dependencies:
@@ -3368,6 +3546,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.17.3":
+  version: 4.17.4
+  resolution: "browserslist@npm:4.17.4"
+  dependencies:
+    caniuse-lite: ^1.0.30001265
+    electron-to-chromium: ^1.3.867
+    escalade: ^3.1.1
+    node-releases: ^2.0.0
+    picocolors: ^1.0.0
+  bin:
+    browserslist: cli.js
+  checksum: b2b7acf1a8c983902de3bc9ed4f23ad471e402d987ed12cc11766b05373a6c239343ca04d28ab0ac06c9e76bf0e37ffbd7f0dcf9bd9f54f4782c26211d40c08a
+  languageName: node
+  linkType: hard
+
+"buble-jsx-only@npm:^0.19.8":
+  version: 0.19.8
+  resolution: "buble-jsx-only@npm:0.19.8"
+  dependencies:
+    acorn: ^6.1.1
+    acorn-dynamic-import: ^4.0.0
+    acorn-jsx: ^5.0.1
+    chalk: ^2.4.2
+    magic-string: ^0.25.3
+    minimist: ^1.2.0
+    regexpu-core: ^4.5.4
+  bin:
+    buble: ./bin/buble
+  checksum: a2b3e1e307506388f0b6f884a1f6c99bd1d508402173c67e3d887046d53b8fadfff40d91fb89502e00b6b3022e9a0bcbf748ed52b414f3acba51adc9b83863a0
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -3471,7 +3681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camel-case@npm:^4.1.1":
+"camel-case@npm:^4.1.1, camel-case@npm:^4.1.2":
   version: 4.1.2
   resolution: "camel-case@npm:4.1.2"
   dependencies:
@@ -3521,6 +3731,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001264, caniuse-lite@npm:^1.0.30001265":
+  version: 1.0.30001269
+  resolution: "caniuse-lite@npm:1.0.30001269"
+  checksum: e544bd20bf4186cc32ef24881ec45a8d61898e37ff4efc7736ad0f7419baf2ec2560de308ec28209f0aae637ec76baea9f1517eaa13cd06b35a14de86b25fc68
+  languageName: node
+  linkType: hard
+
 "ccount@npm:^1.0.0, ccount@npm:^1.0.3":
   version: 1.1.0
   resolution: "ccount@npm:1.1.0"
@@ -3528,7 +3745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.4.1":
+"chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -3539,7 +3756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+"chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -3617,7 +3834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.5.1":
+"chokidar@npm:^3.5.2":
   version: 3.5.2
   resolution: "chokidar@npm:3.5.2"
   dependencies:
@@ -3692,7 +3909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-css@npm:^5.1.2":
+"clean-css@npm:^5.1.5":
   version: 5.2.1
   resolution: "clean-css@npm:5.2.1"
   dependencies:
@@ -3876,6 +4093,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^8.1.0":
+  version: 8.2.0
+  resolution: "commander@npm:8.2.0"
+  checksum: e41e680f2afa0a409aa21d3cad6f06a3d9d2d1086e76223ebd600181b588085e6ad0c7387cf491cb96c60de0a0a50815130368b40bfde017744210d4a8fb75a7
+  languageName: node
+  linkType: hard
+
 "commondir@npm:^1.0.1":
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
@@ -4016,7 +4240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:^9.0.0":
+"copy-webpack-plugin@npm:^9.0.1":
   version: 9.0.1
   resolution: "copy-webpack-plugin@npm:9.0.1"
   dependencies:
@@ -4050,10 +4274,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.9.1":
-  version: 3.18.1
-  resolution: "core-js@npm:3.18.1"
-  checksum: 78ffdaf4a442fc090f5324acba27ed78deb20f9ed7fef04d892b839dddb71dd866432a73416e920e9c0468e45a02d249844090966fa09e4e68a25ef07f2000e7
+"core-js@npm:^3.18.0":
+  version: 3.18.3
+  resolution: "core-js@npm:3.18.3"
+  checksum: 01a927d02974a95313bc2325d9f832bbb4801c0c7e69639392574799f87041ce3dae52bdee3646c7cd58b4f38750a6093ca05363bf9f772be9c38dc69608c25c
   languageName: node
   linkType: hard
 
@@ -4155,15 +4379,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-minimizer-webpack-plugin@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "css-minimizer-webpack-plugin@npm:3.0.2"
+"css-minimizer-webpack-plugin@npm:^3.0.2":
+  version: 3.1.1
+  resolution: "css-minimizer-webpack-plugin@npm:3.1.1"
   dependencies:
     cssnano: ^5.0.6
     jest-worker: ^27.0.2
     p-limit: ^3.0.2
     postcss: ^8.3.5
-    schema-utils: ^3.0.0
+    schema-utils: ^3.1.0
     serialize-javascript: ^6.0.0
     source-map: ^0.6.1
   peerDependencies:
@@ -4173,7 +4397,9 @@ __metadata:
       optional: true
     csso:
       optional: true
-  checksum: 179debffae069fe5ec44be5a0bb8bda0df48f0adae7fde1cbc266f2b28a9d5c5a13d843c22c8682279ac3bd0371bbfe78146cbf5e92538fccb6b662316f6cf2d
+    esbuild:
+      optional: true
+  checksum: 037827f89ba4fb9bf04295840591eb893f4d1ac0c7d5d5c86d7b412ccf80adfafe78beb2bbc26db04a2c1b7435cdd178b421fbadb8bfb4348344907847d44385
   languageName: node
   linkType: hard
 
@@ -4271,7 +4497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano-preset-advanced@npm:^5.1.1":
+"cssnano-preset-advanced@npm:^5.1.4":
   version: 5.1.4
   resolution: "cssnano-preset-advanced@npm:5.1.4"
   dependencies:
@@ -4335,7 +4561,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssnano@npm:^5.0.4, cssnano@npm:^5.0.6":
+"cssnano@npm:^5.0.6, cssnano@npm:^5.0.8":
   version: 5.0.8
   resolution: "cssnano@npm:5.0.8"
   dependencies:
@@ -4772,6 +4998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.3.867":
+  version: 1.3.871
+  resolution: "electron-to-chromium@npm:1.3.871"
+  checksum: 9226692a6b8291047f220a1706b527d6952e4de37b2f87ead9374a3f7eb70989cf98156d333316e3e7d5b1c6cc93c8dd276807c41a94ee0f434e5807f2a84b76
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^7.0.1":
   version: 7.0.3
   resolution: "emoji-regex@npm:7.0.3"
@@ -5021,7 +5254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eta@npm:^1.12.1":
+"eta@npm:^1.12.3":
   version: 1.12.3
   resolution: "eta@npm:1.12.3"
   checksum: 901654d8848028b872b13f392d540fec69c93e297b15faa2697d4cfb13bb007847c8b6cb9fbcf98e6bfc48703e96fee9a986513fc257068c87684c2db9439b11
@@ -5623,7 +5856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"github-slugger@npm:^1.3.0":
+"github-slugger@npm:^1.4.0":
   version: 1.4.0
   resolution: "github-slugger@npm:1.4.0"
   checksum: f6767047f38d6ed15024feae284286447ee11308af38b43422720ca39bb5a4197aa202e4673c5e97410192495689e953cea407e5e83c00360dea802ca3569c87
@@ -6075,7 +6308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-minifier-terser@npm:^5.0.1, html-minifier-terser@npm:^5.1.1":
+"html-minifier-terser@npm:^5.0.1":
   version: 5.1.1
   resolution: "html-minifier-terser@npm:5.1.1"
   dependencies:
@@ -6089,6 +6322,23 @@ __metadata:
   bin:
     html-minifier-terser: cli.js
   checksum: d05dea891f5977a35691306b1fb40438cffd6620c2f5a69d7ecb67bfa836af1d36c24978edd1616dc6d27e230561bd756c5f11b3054e6ebf2f8448289e3ca73d
+  languageName: node
+  linkType: hard
+
+"html-minifier-terser@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "html-minifier-terser@npm:6.0.2"
+  dependencies:
+    camel-case: ^4.1.2
+    clean-css: ^5.1.5
+    commander: ^8.1.0
+    he: ^1.2.0
+    param-case: ^3.0.4
+    relateurl: ^0.2.7
+    terser: ^5.7.2
+  bin:
+    html-minifier-terser: cli.js
+  checksum: 1decfcbd28970b83aff6467a8053459b2a9ee0ae595fc2ab93e2bca00e3f3fe4169bb9a59b0d2ad18def45b946dea7e8c2ac856ddaf3520565e07a1945d358da
   languageName: node
   linkType: hard
 
@@ -6357,10 +6607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infima@npm:0.2.0-alpha.29":
-  version: 0.2.0-alpha.29
-  resolution: "infima@npm:0.2.0-alpha.29"
-  checksum: 15e7f4097c20f005b7ecb0b918e8857a88c0a1ec3f8bc3ec190befdc5422dd9b85e21011f82d33c3f6ef3d91f20ede85d2d0404e5e5a3abdbd8abdbc951b86fe
+"infima@npm:0.2.0-alpha.34":
+  version: 0.2.0-alpha.34
+  resolution: "infima@npm:0.2.0-alpha.34"
+  checksum: 654a348d79059cf1517f14b11723ee61625eca4b4cf28bb586de670e61140fde753671ede54af21fe81cf40c7e6c81c39409f3720aada36c4ec23567fd886fab
   languageName: node
   linkType: hard
 
@@ -7027,7 +7277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.3.0, joi@npm:^17.4.0":
+"joi@npm:^17.4.0, joi@npm:^17.4.2":
   version: 17.4.2
   resolution: "joi@npm:17.4.2"
   dependencies:
@@ -7268,7 +7518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^1.2.3, loader-utils@npm:^1.4.0":
+"loader-utils@npm:^1.4.0":
   version: 1.4.0
   resolution: "loader-utils@npm:1.4.0"
   dependencies:
@@ -7480,6 +7730,15 @@ __metadata:
   dependencies:
     yallist: ^4.0.0
   checksum: b8b78353d2391c0f135cdc245c4744ad41c2efb1a6d98f31bc57a2cf48ebf02de96e4876657c3026673576bf1f1f61fc3fdd77ab00ad1ead737537bf17d8019d
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.25.3":
+  version: 0.25.7
+  resolution: "magic-string@npm:0.25.7"
+  dependencies:
+    sourcemap-codec: ^1.4.4
+  checksum: 4b70c13eb21c6f1c54bf7fb029748dc44d6bfcd3c59e5deeda060eecc38df6144b91d10fb7a3cf6156fadab1a68f83d69a189df20ca5f6bd088bf0196ea8f039
   languageName: node
   linkType: hard
 
@@ -7982,6 +8241,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.1.28":
+  version: 3.1.30
+  resolution: "nanoid@npm:3.1.30"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 440f685e9890bd96433cf6c01535165b1e9677ba4a5c4179e1a61612f0b4c428cc628425fe232038b93304d15b191892d7ced9503fa558d1296e4e95fe80a627
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -8086,6 +8354,13 @@ __metadata:
   version: 1.1.77
   resolution: "node-releases@npm:1.1.77"
   checksum: acc54c73e9a23a854bc04c3e5b948e9f043498e744b8bc7b9169331fed0fba291cb60adc4552809d6d95ef9ed45d16047441205cd80d33c140c68ee0fb767dfc
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "node-releases@npm:2.0.0"
+  checksum: 072914baf9eab6cc4fb051935acf6a4f9974ab47224794375c817513ca3645dc9f3a65a821e9c6a6d54213e771c4d49db8cff0b6b8bb6b9b31424c815c716829
   languageName: node
   linkType: hard
 
@@ -8474,7 +8749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"param-case@npm:^3.0.3":
+"param-case@npm:^3.0.3, param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
   dependencies:
@@ -8519,7 +8794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-numeric-range@npm:^1.2.0":
+"parse-numeric-range@npm:^1.3.0":
   version: 1.3.0
   resolution: "parse-numeric-range@npm:1.3.0"
   checksum: d051fd4f459cbfe75236216a12fdd90a62a4d2e8cb13008f9ae4c48602e79570d8ce11c413803c52d418c2599cd6a6040ea7692a35f404ca3942cb4b008e48f8
@@ -8647,6 +8922,20 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: ef5835f2eb47e4d06004c7ec7bd51175c0455eaecd5ee99a9774bca5ef43242616e25b44ccc0ba86a0bf42b9f197550fcc0dfa7580e5ff9dca53c035e9bd86a9
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "picocolors@npm:0.2.1"
+  checksum: 84da675558ed004c61a7fa7b0bcce6338c8e3ef1eadb43b5263059d1d745f4567464aa6aa603c506a82942a5a7dfda5bb023605a5f4c9888d7adc154845d579e
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "picocolors@npm:1.0.0"
+  checksum: 6616d34dd03bde8881c63402dea34f0b5972845b04b791b234446d4a408bc3d7f932acea3970a6b671d8f5c5aae1b1ce9fc1f89b0ed9a363469cf9da8e916b71
   languageName: node
   linkType: hard
 
@@ -8816,17 +9105,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-loader@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "postcss-loader@npm:5.3.0"
+"postcss-loader@npm:^6.1.1":
+  version: 6.2.0
+  resolution: "postcss-loader@npm:6.2.0"
   dependencies:
     cosmiconfig: ^7.0.0
     klona: ^2.0.4
-    semver: ^7.3.4
+    semver: ^7.3.5
   peerDependencies:
     postcss: ^7.0.0 || ^8.0.1
     webpack: ^5.0.0
-  checksum: fd7a1a673b0e8f238392b3d449f2727767522febb2f60bfc9bb5cd4e373b07ba8df621f4e2fad92bf085765dcdea0f049497ae799ce1c9f1a592820275cc7e65
+  checksum: 2583b1d33c7ec964431adc768adfed1e339f59803bf6fbf6cc76226159cf01e67d7f83773e4926f183e44c9ce38ef82e52b2a1ef9d9e4288f789622fa97b6af8
   languageName: node
   linkType: hard
 
@@ -9125,14 +9414,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-sort-media-queries@npm:^3.10.11":
-  version: 3.12.13
-  resolution: "postcss-sort-media-queries@npm:3.12.13"
+"postcss-sort-media-queries@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "postcss-sort-media-queries@npm:4.1.0"
   dependencies:
     sort-css-media-queries: 2.0.4
   peerDependencies:
     postcss: ^8.3.6
-  checksum: df755f302dcd54de62a7fc55f6e123fe432831fdb09efe9e93f0bf1769251bd7aecfa37efdd51ec11f8f6a9289dcf156bd0f472e4f2e024597ceeaab9557c45f
+  checksum: b1f67387688e02c9b2719d80a83cfb95256ff51a43da0fbdf8773fa1d771b63ba6471ab6469e9a4e9cdd30a783a7ae4855cd01ae3cf307102bbe8f10cd314025
   languageName: node
   linkType: hard
 
@@ -9185,6 +9474,17 @@ __metadata:
     nanoid: ^3.1.25
     source-map-js: ^0.6.2
   checksum: bea4f2f367c803739ca89c6773aa80ecad6480171db7e1ebb211fabe7eaf7ff68b3b4d007e41f84d561344a588d62d1b50b3e46e1f5c368712100df553fc09ca
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.3.7":
+  version: 8.3.9
+  resolution: "postcss@npm:8.3.9"
+  dependencies:
+    nanoid: ^3.1.28
+    picocolors: ^0.2.1
+    source-map-js: ^0.6.2
+  checksum: f67654ab01ec6ec9126eb5ed64b06f602dfce7e6a38aa7f4d3cdb67fe40fe97234286c5fd6769f56138206ea80e944c62f909052b00c351239064ef3b850664d
   languageName: node
   linkType: hard
 
@@ -9723,7 +10023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reading-time@npm:^1.3.0":
+"reading-time@npm:^1.5.0":
   version: 1.5.0
   resolution: "reading-time@npm:1.5.0"
   checksum: 2d2342095a8640dfa787dc44c52cfc567d9ed7143b86b28476e9e8ce521a2e3be7d0aa7ee30b5e5af430c0dc79ec8aa5afa745987c4538df322a478c2a69541d
@@ -9800,7 +10100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpu-core@npm:^4.7.1":
+"regexpu-core@npm:^4.5.4, regexpu-core@npm:^4.7.1":
   version: 4.8.0
   resolution: "regexpu-core@npm:4.8.0"
   dependencies:
@@ -9894,6 +10194,24 @@ __metadata:
   version: 2.0.0
   resolution: "remark-footnotes@npm:2.0.0"
   checksum: fbf8224b7f84be15098847ff9dc31ba8886be16a83c42f69ea7aa81070cdfa121f7b694ff24adc54aea65beab4825e148e6ff8a145fee446befa0471ff0a780f
+  languageName: node
+  linkType: hard
+
+"remark-mdx-remove-exports@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "remark-mdx-remove-exports@npm:1.6.22"
+  dependencies:
+    unist-util-remove: 2.0.0
+  checksum: e868a3372e5b86fe6b6ce84951c02791d5fdc01b1bdd3c492cad9f659952161fe00db251894faa7b17ba73e538b5010144fd99325019eebceb538306172b4328
+  languageName: node
+  linkType: hard
+
+"remark-mdx-remove-imports@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "remark-mdx-remove-imports@npm:1.6.22"
+  dependencies:
+    unist-util-remove: 2.0.0
+  checksum: 42cf716898db678ba5d6566ff032bfc0916096429f5519e8d921aa2fee34a38bb3a7cbddfaeff95f251079077625377e79e05e120a28996e3f82b32461e460dd
   languageName: node
   linkType: hard
 
@@ -10111,8 +10429,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@docusaurus/core": 2.0.0-beta.4
-    "@docusaurus/preset-classic": 2.0.0-beta.4
+    "@docusaurus/core": 2.0.0-beta.7
+    "@docusaurus/preset-classic": 2.0.0-beta.7
     classnames: ^2.2.6
     netlify-plugin-cache: ^1.0.3
     react: ^17.0.2
@@ -10122,16 +10440,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"rtl-detect@npm:^1.0.3":
+"rtl-detect@npm:^1.0.4":
   version: 1.0.4
   resolution: "rtl-detect@npm:1.0.4"
   checksum: 63e6b4a1e6ff0e8df91d2c0ed76c2c0626ec35844cc8912f80d371dd2e9f1a6f48636ae315fe2e25c6136fe606038894ef9bab3b264cd2769c95ec4198a08f21
   languageName: node
   linkType: hard
 
-"rtlcss@npm:^3.1.2":
-  version: 3.3.0
-  resolution: "rtlcss@npm:3.3.0"
+"rtlcss@npm:^3.3.0":
+  version: 3.4.0
+  resolution: "rtlcss@npm:3.4.0"
   dependencies:
     chalk: ^4.1.0
     find-up: ^5.0.0
@@ -10142,7 +10460,7 @@ __metadata:
     postcss: ^8.2.4
   bin:
     rtlcss: bin/rtlcss.js
-  checksum: c5fbd799a5d2463b9b521396015bd28c5225e43d0eae1c3e8298d684b8cae38d3ae564e6df450b2b8e1a981315f67014fdaa1aa99081f5af9a9f5cd67a63f2a4
+  checksum: 6a77af8d8d7e5c45ada481180bfe6d6e5b1c9ad718e1b0ddefa941f7e113fa7671a2df8e0df555b0bd7de33c384a876b52af01f2f3e081440bb06106c94cce5f
   languageName: node
   linkType: hard
 
@@ -10155,12 +10473,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.6.3":
-  version: 6.6.7
-  resolution: "rxjs@npm:6.6.7"
+"rxjs@npm:^7.1.0":
+  version: 7.4.0
+  resolution: "rxjs@npm:7.4.0"
   dependencies:
-    tslib: ^1.9.0
-  checksum: 1146975cbd5388ee5e61450235dc5670931e43cce71813f567977d334acc4d75c6e8d9d293df67e1fb31510b99fc8957943d4a9b550d109e4dc69967a8471543
+    tslib: ~2.1.0
+  checksum: e58ecc0496ba710fcf00238f1fd44968f7133e87a0a43c244e508494425c188f20078905fa397c427d270cc6496b62d07de7bb3252d71c93d62d13cdc958b577
   languageName: node
   linkType: hard
 
@@ -10709,6 +11027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sourcemap-codec@npm:^1.4.4":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: 4d56d1232a45af813606d1755f11e7ae6b3542c615a7e3f904382f0134a9412ba8d090e83749254d78449eafdfcc62d5158b8f35e6241480b51b74b5c46b99f9
+  languageName: node
+  linkType: hard
+
 "space-separated-tokens@npm:^1.0.0":
   version: 1.1.5
   resolution: "space-separated-tokens@npm:1.1.5"
@@ -11112,7 +11437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.3":
+"terser-webpack-plugin@npm:^5.1.3, terser-webpack-plugin@npm:^5.2.4":
   version: 5.2.4
   resolution: "terser-webpack-plugin@npm:5.2.4"
   dependencies:
@@ -11292,17 +11617,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.9.0":
-  version: 1.14.1
-  resolution: "tslib@npm:1.14.1"
-  checksum: f44fe7f216946b17d3e3074df3746372703cf24e9127b4c045511456e8e4bf25515fb0a1bb3937676cc305651c5d4fcb6377b0588a4c6a957e748c4c28905d17
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0":
+"tslib@npm:^2.0.3, tslib@npm:^2.3.1":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: 5ae2f209c5127bad284974c78916f02c72082615f65889a7ed0c7ca6d5f935c30338a0ee7310e1d9652dabc7b7507fd2905035487446d09d45fc1f19de71cf05
+  languageName: node
+  linkType: hard
+
+"tslib@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "tslib@npm:2.1.0"
+  checksum: d8f5bdd067611651c6b846c2388f4dc8ba1f5af124e66105f5263d1ad56da17f4b8c6566887ca2f205c5a9758451871ceca87d5d06087af2dca1699c5e33db69
   languageName: node
   linkType: hard
 
@@ -11506,6 +11831,15 @@ __metadata:
   dependencies:
     unist-util-visit: ^2.0.0
   checksum: 0b1a7046c45ab74da969ff269d4fad711d4e15e2dba6f6aa9020845b0a4c2a2733d9fdd437ad46da49be6146f88fbc66db92ee8c45c6d195943003303dc2f8b0
+  languageName: node
+  linkType: hard
+
+"unist-util-remove@npm:2.0.0":
+  version: 2.0.0
+  resolution: "unist-util-remove@npm:2.0.0"
+  dependencies:
+    unist-util-is: ^4.0.0
+  checksum: 7e79d9f95d14ad9697d80e5e74094262d6a2bf207cff75b079257f1123c614b30a9192007724e9cea10f598cb1b16fc243ed0ef7bce71c56253b17127a2f0c08
   languageName: node
   linkType: hard
 
@@ -11820,18 +12154,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wait-on@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "wait-on@npm:5.3.0"
+"wait-on@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "wait-on@npm:6.0.0"
   dependencies:
     axios: ^0.21.1
-    joi: ^17.3.0
+    joi: ^17.4.0
     lodash: ^4.17.21
     minimist: ^1.2.5
-    rxjs: ^6.6.3
+    rxjs: ^7.1.0
   bin:
     wait-on: bin/wait-on
-  checksum: 405cad859a3ede2b48ebe7a3e39e543adff21333ac3e309b1469bffa71952db0c0920bebabf5d7282e8709bd43c2bab312ed6e764cdae149986b57dc0b263ff9
+  checksum: c43c09f02b0b23582150cab4d6779e76fa511f78dc920ce892c3ccd4cc9e342726ef993c2186fead7f5760d8ea2b01bcab6b2fd075ffdfa97a1db0957345a568
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This doesn't address any specific issue occurring on the react-redux docs, but brings miscellaneous docusaurus fixes/changes in, future-proofing for further additions (e.g. better handling if/when TS/JS tab support is added).

e.g. as per https://github.com/reduxjs/redux-toolkit/pull/1620