### PR TITLE
docs: remove unnecessary import

### DIFF
--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -143,7 +143,7 @@ export default configureStore({
 Now we can use the React Redux hooks to let React components interact with the Redux store. We can read data from the store with `useSelector`, and dispatch actions using `useDispatch`. Create a `src/features/counter/Counter.js` file with a `<Counter>` component inside, then import that component into `App.js` and render it inside of `<App>`.
 
 ```jsx title="features/counter/Counter.js"
-import React, { useState } from 'react'
+import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { decrement, increment } from './counterSlice'
 import styles from './Counter.module.css'


### PR DESCRIPTION
`useState` is not used, but imported.