### PR TITLE
[DRAFT] Add partial SSR support (Provider and useSelector)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^18.0.0-beta"
+    "react": "^18.0.0-rc"
   },
   "peerDependenciesMeta": {
     "react-dom": {
@@ -52,15 +52,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.1",
-    "@testing-library/react-12": "npm:@testing-library/react@^12",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/use-sync-external-store": "^0.0.3",
     "hoist-non-react-statics": "^3.3.2",
-    "react-17": "npm:react@^17",
-    "react-dom-17": "npm:react-dom@^17",
-    "react-is": "^18.0.0-beta-fdc1d617a-20211118",
-    "react-test-renderer-17": "npm:react-test-renderer@^17",
-    "use-sync-external-store": "1.0.0-beta-fdc1d617a-20211118"
+    "react-is": "^18.0.0-rc.0",
+    "use-sync-external-store": "^1.0.0-rc.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -81,6 +77,7 @@
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/jest-native": "^3.4.3",
     "@testing-library/react": "13.0.0-alpha.4",
+    "@testing-library/react-12": "npm:@testing-library/react@^12",
     "@testing-library/react-hooks": "^3.4.2",
     "@testing-library/react-native": "^7.1.0",
     "@types/object-assign": "^4.0.30",
@@ -104,9 +101,12 @@
     "jest": "^26.6.1",
     "prettier": "^2.1.2",
     "react": "18.0.0-beta-fdc1d617a-20211118",
+    "react-17": "npm:react@^17",
     "react-dom": "18.0.0-beta-fdc1d617a-20211118",
+    "react-dom-17": "npm:react-dom@^17",
     "react-native": "^0.64.1",
     "react-test-renderer": "18.0.0-beta-fdc1d617a-20211118",
+    "react-test-renderer-17": "npm:react-test-renderer@^17",
     "redux": "^4.0.5",
     "rimraf": "^3.0.2",
     "rollup": "^2.32.1",

--- a/src/components/Context.ts
+++ b/src/components/Context.ts
@@ -8,6 +8,7 @@ export interface ReactReduxContextValue<
 > {
   store: Store<SS, A>
   subscription: Subscription
+  getServerState?: () => SS
 }
 
 export const ReactReduxContext =

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -4,17 +4,23 @@ import { createSubscription } from '../utils/Subscription'
 import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
 import { Action, AnyAction, Store } from 'redux'
 
-export interface ProviderProps<A extends Action = AnyAction> {
+export interface ProviderProps<A extends Action = AnyAction, S = any> {
   /**
    * The single Redux store in your application.
    */
-  store: Store<any, A>
+  store: Store<S, A>
+
+  /**
+   * An optional server state snapshot. Will be used during initial hydration render if available, to ensure that the UI output is consistent with the HTML generated on the server.
+   */
+  serverState?: S
+
   /**
    * Optional context to be used internally in react-redux. Use React.createContext() to create a context to be used.
    * If this is used, you'll need to customize `connect` by supplying the same context provided to the Provider.
    * Initial value doesn't matter, as it is overwritten with the internal state of Provider.
    */
-  context?: Context<ReactReduxContextValue<any, A>>
+  context?: Context<ReactReduxContextValue<S, A>>
   children: ReactNode
 }
 
@@ -22,14 +28,16 @@ function Provider<A extends Action = AnyAction>({
   store,
   context,
   children,
+  serverState,
 }: ProviderProps<A>) {
   const contextValue = useMemo(() => {
     const subscription = createSubscription(store)
     return {
       store,
       subscription,
+      getServerState: serverState ? () => serverState : undefined,
     }
-  }, [store])
+  }, [store, serverState])
 
   const previousState = useMemo(() => store.getState(), [store])
 

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -602,7 +602,7 @@ function connect<
         ? props.store!
         : contextValue!.store
 
-      const getServerSnapshot = didStoreComeFromContext
+      const getServerState = didStoreComeFromContext
         ? contextValue.getServerState
         : store.getState
 
@@ -738,8 +738,9 @@ function connect<
           // TODO This is incredibly hacky. We've already processed the store update and calculated new child props,
           // TODO and we're just passing that through so it triggers a re-render for us rather than relying on `uSES`.
           actualChildPropsSelector,
-          // TODO Need a real getServerSnapshot here
-          actualChildPropsSelector
+          getServerState
+            ? () => childPropsSelector(getServerState(), wrapperProps)
+            : actualChildPropsSelector
         )
       } catch (err) {
         if (latestSubscriptionCallbackError.current) {

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -48,13 +48,13 @@ export function createSelectorHook(
       }
     }
 
-    const { store } = useReduxContext()!
+    const { store, getServerState } = useReduxContext()!
 
     const selectedState = useSyncExternalStoreWithSelector(
       store.subscribe,
       store.getState,
       // TODO Need a server-side snapshot here
-      store.getState,
+      getServerState || store.getState,
       selector,
       equalityFn
     )

--- a/src/utils/useIsomorphicLayoutEffect.ts
+++ b/src/utils/useIsomorphicLayoutEffect.ts
@@ -9,9 +9,11 @@ import { useEffect, useLayoutEffect } from 'react'
 // is created synchronously, otherwise a store update may occur before the
 // subscription is created and an inconsistent state may be observed
 
-export const useIsomorphicLayoutEffect =
+// Matches logic in React's `shared/ExecutionEnvironment` file
+export const canUseDOM = !!(
   typeof window !== 'undefined' &&
   typeof window.document !== 'undefined' &&
   typeof window.document.createElement !== 'undefined'
-    ? useLayoutEffect
-    : useEffect
+)
+
+export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect

--- a/yarn.lock
+++ b/yarn.lock
@@ -8837,7 +8837,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:18.0.0-beta-fdc1d617a-20211118, react-is@npm:^18.0.0-beta-fdc1d617a-20211118":
+"react-is@npm:18.0.0-beta-fdc1d617a-20211118":
   version: 18.0.0-beta-fdc1d617a-20211118
   resolution: "react-is@npm:18.0.0-beta-fdc1d617a-20211118"
   checksum: 402e28c80019e9deaee919c4373606736ea36142d1d1e09e0cab89d52e8bd647f1176a383987cca5c4e83bfee33bba8091ab347363ea4bdd4f9c3a707812c8b9
@@ -8855,6 +8855,13 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 11bcf1267a314a522615f626f3ce3727a3a24cdbf61c4d452add3550a7875326669631326cfb1ba3e92b6f72244c32ffecf93ad21c0cad8455d3e169d0e3f060
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^18.0.0-rc.0":
+  version: 18.0.0-rc.0-next-f2a59df48-20211208
+  resolution: "react-is@npm:18.0.0-rc.0-next-f2a59df48-20211208"
+  checksum: e0f8b1c8ef759153072b7508f8832164651aa855c9c939d607090899d9d522c68ad12ec9630f34a56c46330542356207dfc09d744b8ffe2eccc45a83f296fcae
   languageName: node
   linkType: hard
 
@@ -8966,7 +8973,7 @@ __metadata:
     react-17: "npm:react@^17"
     react-dom: 18.0.0-beta-fdc1d617a-20211118
     react-dom-17: "npm:react-dom@^17"
-    react-is: ^18.0.0-beta-fdc1d617a-20211118
+    react-is: ^18.0.0-rc.0
     react-native: ^0.64.1
     react-test-renderer: 18.0.0-beta-fdc1d617a-20211118
     react-test-renderer-17: "npm:react-test-renderer@^17"
@@ -8976,9 +8983,9 @@ __metadata:
     rollup-plugin-terser: ^7.0.2
     ts-jest: 26.5.6
     typescript: ^4.3.4
-    use-sync-external-store: 1.0.0-beta-fdc1d617a-20211118
+    use-sync-external-store: ^1.0.0-rc.0
   peerDependencies:
-    react: ^18.0.0-beta
+    react: ^18.0.0-rc
   peerDependenciesMeta:
     react-dom:
       optional: true
@@ -10845,12 +10852,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:1.0.0-beta-fdc1d617a-20211118":
-  version: 1.0.0-beta-fdc1d617a-20211118
-  resolution: "use-sync-external-store@npm:1.0.0-beta-fdc1d617a-20211118"
+"use-sync-external-store@npm:^1.0.0-rc.0":
+  version: 1.0.0-rc.0-next-f2a59df48-20211208
+  resolution: "use-sync-external-store@npm:1.0.0-rc.0-next-f2a59df48-20211208"
   peerDependencies:
-    react: 18.0.0-beta-fdc1d617a-20211118
-  checksum: bb52d87a886731595163a3b6a07b671f9ea92ca6de35791f32ce186e2fea0f2989088f3dacfea3dff258e866e767ff1e87d18494e436523e67b17e59051a22e0
+    react: 18.0.0-rc.0-next-f2a59df48-20211208
+  checksum: 772bf9fe4b47f9cf21969cc839e21e11e2fbad63e4992c75402fabed7048f5afb559bee289c9a0c3b4bad7c1c5724f6cb63c5499ef7f249c395e86233102bccb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

- Updates the context types to include a `getServerState` field
- Updates `Provider` to accept a `serverState` prop, and if included, pass down a `getServerState` callback that returns that value
- Updates `useSelector` to pass `getServerState` to `uSES`
- Identifies areas where `connect` is almost definitely abusing `uSES` :)

I'd like to get some eyes on what I've got so far and find out if I'm headed in the right direction overall.  The changes here are based on comments made by @acdlite in various React 18 Working Group discussions.

I'm also interested in example tests we can use to verify that any of these changes are working as intended - please offer suggestions or PRs!

`connect`'s logic is screwy because we need to know if the child props are being recalculated _first_, so that we either trigger a re-render or go ahead and cascade the subscription notifications down the tree.  As a result, my current code still has `connect` doing _all_ the actual meaningful comparison work, and then abusing `uSES` by passing down the "child props selector" function as the `getSnapshot` argument to `uSES`.  The actual call to `getState` still happens within `connect` itself.

This has at least passed all our tests so far, but now that I'm trying to figure out how to potentially take the `getServerState` callback and pass it to `uSES`, I'm pretty sure all of this is basically incorrect usage :)

This suggests there are three possibilities:

- Some hypothetical fix that involves just shuffling pieces around and somehow it'll end up being sufficiently okay to work
- Completely rewriting the guts of `connect` + the `mapState/mapDispatch` logic (which has been basically as-is and untouched since it was written in late 2016) in order to better accomodate the revised requirements
- Leave `connect` as-is and say "look, it'll _run_ okay, but if SSR hydration is your concern we just can't fully support that - it's too difficult.  So, if you're still using `connect` you'll have to accept whatever fallback behavior React does here".

Paging interested parties:

@acdlite @timdorr @eps1lon @phryneas @dai-shi @Andarist 