### PR TITLE
fix: Add types to ensure that there will be no compilation errors when struct: false

### DIFF
--- a/src/utils/Subscription.ts
+++ b/src/utils/Subscription.ts
@@ -34,7 +34,7 @@ function createListenerCollection() {
     },
 
     get() {
-      let listeners = []
+      let listeners: Listener[] = []
       let listener = first
       while (listener) {
         listeners.push(listener)


### PR DESCRIPTION
I used the v8 version of react-redux in the project.

When typescript is configured with `strict: true`, The type of `let listeners = []` is recognized as `any[]`.

When typescript is configured with `strict: false`, The type of `let listeners = []` is recognized as `never[]`, 
This will cause `listeners.push(listener)` to prompt the error `TS2345: Argument of type 'Listener' is not assignable to parameter of type'never'.`.

When project is not configured with `strict: true`, this will cause a project compile-time error, so I added a type here to solve this problem.