### PR TITLE
Port remaining v7 typetests and improve v8 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare": "yarn clean && yarn build",
     "pretest": "yarn lint",
     "test": "jest",
-    "type-tests": "yarn tsc -p test/typetests",
+    "type-tests": "yarn tsc -p test/typetests/tsconfig.json",
     "coverage": "codecov"
   },
   "peerDependencies": {

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -2,24 +2,27 @@ import React, { Context, ReactNode, useMemo } from 'react'
 import { ReactReduxContext, ReactReduxContextValue } from './Context'
 import { createSubscription } from '../utils/Subscription'
 import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
-import type { FixTypeLater } from '../types'
 import { Action, AnyAction, Store } from 'redux'
 
 export interface ProviderProps<A extends Action = AnyAction> {
   /**
    * The single Redux store in your application.
    */
-  store: Store<FixTypeLater, A>
+  store: Store<any, A>
   /**
    * Optional context to be used internally in react-redux. Use React.createContext() to create a context to be used.
    * If this is used, you'll need to customize `connect` by supplying the same context provided to the Provider.
    * Initial value doesn't matter, as it is overwritten with the internal state of Provider.
    */
-  context?: Context<ReactReduxContextValue>
+  context?: Context<ReactReduxContextValue<any, A>>
   children: ReactNode
 }
 
-function Provider({ store, context, children }: ProviderProps) {
+function Provider<A extends Action = AnyAction>({
+  store,
+  context,
+  children,
+}: ProviderProps<A>) {
   const contextValue = useMemo(() => {
     const subscription = createSubscription(store)
     return {
@@ -46,6 +49,7 @@ function Provider({ store, context, children }: ProviderProps) {
 
   const Context = context || ReactReduxContext
 
+  // @ts-ignore 'AnyAction' is assignable to the constraint of type 'A', but 'A' could be instantiated with a different subtype
   return <Context.Provider value={contextValue}>{children}</Context.Provider>
 }
 

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -260,183 +260,163 @@ export interface ConnectOptions<
   ) => boolean
 }
 
-/* @public */
-function connect(): InferableComponentEnhancer<DispatchProp>
+/**
+ * Connects a React component to a Redux store.
+ *
+ * - Without arguments, just wraps the component, without changing the behavior / props
+ *
+ * - If 2 params are passed (3rd param, mergeProps, is skipped), default behavior
+ * is to override ownProps (as stated in the docs), so what remains is everything that's
+ * not a state or dispatch prop
+ *
+ * - When 3rd param is passed, we don't know if ownProps propagate and whether they
+ * should be valid component props, because it depends on mergeProps implementation.
+ * As such, it is the user's responsibility to extend ownProps interface from state or
+ * dispatch props or both when applicable
+ *
+ * @param mapStateToProps
+ * @param mapDispatchToProps
+ * @param mergeProps
+ * @param options
+ */
+export interface Connect<DefaultState = DefaultRootState> {
+  // tslint:disable:no-unnecessary-generics
+  (): InferableComponentEnhancer<DispatchProp>
 
-/* @public */
-function connect<
-  TStateProps = {},
-  no_dispatch = {},
-  TOwnProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
-): InferableComponentEnhancerWithProps<
-  TStateProps & DispatchProp,
-  TOwnProps & ConnectProps
->
+  /** mapState only */
+  <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
+  ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>
 
-/* @public */
-function connect<no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
-  mapStateToProps: null | undefined,
-  mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
-): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps & ConnectProps>
+  /** mapDispatch only (as a function) */
+  <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
 
-/* @public */
-function connect<no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
-  mapStateToProps: null | undefined,
-  mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  ResolveThunks<TDispatchProps>,
-  TOwnProps & ConnectProps
->
+  /** mapDispatch only (as an object) */
+  <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    ResolveThunks<TDispatchProps>,
+    TOwnProps
+  >
 
-/* @public */
-function connect<
-  TStateProps = {},
-  TDispatchProps = {},
-  TOwnProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  TStateProps & TDispatchProps,
-  TOwnProps & ConnectProps
->
+  /** mapState and mapDispatch (as a function)*/
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
 
-/* @public */
-function connect<
-  TStateProps = {},
-  TDispatchProps = {},
-  TOwnProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  TStateProps & ResolveThunks<TDispatchProps>,
-  TOwnProps & ConnectProps
->
+  /** mapState and mapDispatch (as an object) */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & ResolveThunks<TDispatchProps>,
+    TOwnProps
+  >
 
-/* @public */
-function connect<
-  no_state = {},
-  no_dispatch = {},
-  TOwnProps = {},
-  TMergedProps = {}
->(
-  mapStateToProps: null | undefined,
-  mapDispatchToProps: null | undefined,
-  mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps & ConnectProps>
+  /** mergeProps only */
+  <no_state = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: null | undefined,
+    mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-/* @public */
-function connect<
-  TStateProps = {},
-  no_dispatch = {},
-  TOwnProps = {},
-  TMergedProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps: null | undefined,
-  mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps & ConnectProps>
+  /** mapState and mergeProps */
+  <
+    TStateProps = {},
+    no_dispatch = {},
+    TOwnProps = {},
+    TMergedProps = {},
+    State = DefaultState
+  >(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: null | undefined,
+    mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-/* @public */
-function connect<
-  no_state = {},
-  TDispatchProps = {},
-  TOwnProps = {},
-  TMergedProps = {}
->(
-  mapStateToProps: null | undefined,
-  mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-  mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps & ConnectProps>
+  /** mapDispatch (as a object) and mergeProps */
+  <no_state = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-/* @public */
-// @ts-ignore
-function connect<
-  TStateProps = {},
-  no_dispatch = {},
-  TOwnProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps: null | undefined,
-  mergeProps: null | undefined,
-  options: ConnectOptions<State, TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  DispatchProp & TStateProps,
-  TOwnProps & ConnectProps
->
+  /** mapState and options */
+  <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: null | undefined,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<DispatchProp & TStateProps, TOwnProps>
 
-/* @public */
-function connect<TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
-  mapStateToProps: null | undefined,
-  mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
-  mergeProps: null | undefined,
-  options: ConnectOptions<{}, TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps & ConnectProps>
+  /** mapDispatch (as a function) and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<{}, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
 
-/* @public */
-function connect<TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
-  mapStateToProps: null | undefined,
-  mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-  mergeProps: null | undefined,
-  options: ConnectOptions<{}, TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  ResolveThunks<TDispatchProps>,
-  TOwnProps & ConnectProps
->
+  /** mapDispatch (as an object) and options*/
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<{}, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    ResolveThunks<TDispatchProps>,
+    TOwnProps
+  >
 
-/* @public */
-function connect<
-  TStateProps = {},
-  TDispatchProps = {},
-  TOwnProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
-  mergeProps: null | undefined,
-  options: ConnectOptions<State, TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  TStateProps & TDispatchProps,
-  TOwnProps & ConnectProps
->
+  /** mapState,  mapDispatch (as a function), and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
 
-/* @public */
-function connect<
-  TStateProps = {},
-  TDispatchProps = {},
-  TOwnProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-  mergeProps: null | undefined,
-  options: ConnectOptions<State, TStateProps, TOwnProps>
-): InferableComponentEnhancerWithProps<
-  TStateProps & ResolveThunks<TDispatchProps>,
-  TOwnProps & ConnectProps
->
+  /** mapState,  mapDispatch (as an object), and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & ResolveThunks<TDispatchProps>,
+    TOwnProps
+  >
 
-/* @public */
-function connect<
-  TStateProps = {},
-  TDispatchProps = {},
-  TOwnProps = {},
-  TMergedProps = {},
-  State = DefaultRootState
->(
-  mapStateToProps?: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-  mapDispatchToProps?: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-  mergeProps?: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-  options?: ConnectOptions<State, TStateProps, TOwnProps, TMergedProps>
-): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps & ConnectProps>
+  /** mapState, mapDispatch, mergeProps, and options */
+  <
+    TStateProps = {},
+    TDispatchProps = {},
+    TOwnProps = {},
+    TMergedProps = {},
+    State = DefaultState
+  >(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mergeProps: MergeProps<
+      TStateProps,
+      TDispatchProps,
+      TOwnProps,
+      TMergedProps
+    >,
+    options?: ConnectOptions<State, TStateProps, TOwnProps, TMergedProps>
+  ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
+  // tslint:enable:no-unnecessary-generics
+}
 
 /**
  * Connects a React component to a Redux store.
@@ -826,4 +806,4 @@ function connect<
   return wrapWithConnect
 }
 
-export default connect
+export default connect as Connect

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -192,9 +192,14 @@ function subscribeUpdates(
 const initStateUpdates = () => EMPTY_ARRAY
 
 export interface ConnectProps {
-  reactReduxForwardedRef?: React.ForwardedRef<unknown>
+  /** A custom Context instance that the component can use to access the store from an alternate Provider using that same Context instance */
   context?: ReactReduxContextInstance
+  /** A Redux store instance to be used for subscriptions instead of the store from a Provider */
   store?: Store
+}
+
+interface InternalConnectProps extends ConnectProps {
+  reactReduxForwardedRef?: React.ForwardedRef<unknown>
 }
 
 function match<T>(
@@ -538,7 +543,9 @@ function connect<
     // that just executes the given callback immediately.
     const usePureOnlyMemo = pure ? useMemo : (callback: () => any) => callback()
 
-    function ConnectFunction<TOwnProps>(props: ConnectProps & TOwnProps) {
+    function ConnectFunction<TOwnProps>(
+      props: InternalConnectProps & TOwnProps
+    ) {
       const [propsContext, reactReduxForwardedRef, wrapperProps] =
         useMemo(() => {
           // Distinguish between actual "data" props that were passed to the wrapper component,

--- a/src/connect/selectorFactory.ts
+++ b/src/connect/selectorFactory.ts
@@ -231,14 +231,12 @@ export default function finalPropsSelectorFactory<
     verifySubselectors(mapStateToProps, mapDispatchToProps, mergeProps)
   }
 
-  const selectorFactory = pureFinalPropsSelectorFactory
-
-  return selectorFactory(
+  return pureFinalPropsSelectorFactory<
+    TStateProps,
+    TOwnProps,
+    TDispatchProps,
+    TMergedProps,
+    State
     // @ts-ignore
-    mapStateToProps!,
-    mapDispatchToProps,
-    mergeProps,
-    dispatch,
-    options
-  )
+  >(mapStateToProps!, mapDispatchToProps, mergeProps, dispatch, options)
 }

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,6 +1,7 @@
 import Provider from './components/Provider'
 import type { ProviderProps } from './components/Provider'
-import connect, {
+import connect from './components/connect'
+import type {
   Connect,
   ConnectProps,
   ConnectedProps,
@@ -36,6 +37,7 @@ export type {
   MapStateToProps,
   MapStateToPropsFactory,
   MapStateToPropsParam,
+  Connect,
   ConnectProps,
   ConnectedProps,
   MapDispatchToPropsFunction,
@@ -51,7 +53,6 @@ export {
   Provider,
   ReactReduxContext,
   connect,
-  Connect,
   useDispatch,
   createDispatchHook,
   useSelector,

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -2,6 +2,7 @@ import Provider from './components/Provider'
 import type { ProviderProps } from './components/Provider'
 import connect, {
   Connect,
+  ConnectProps,
   ConnectedProps,
 } from './components/connect'
 import type {

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,6 +1,9 @@
 import Provider from './components/Provider'
 import type { ProviderProps } from './components/Provider'
-import connect, { ConnectProps, ConnectedProps } from './components/connect'
+import connect, {
+  Connect,
+  ConnectedProps,
+} from './components/connect'
 import type {
   SelectorFactory,
   Selector,
@@ -47,6 +50,7 @@ export {
   Provider,
   ReactReduxContext,
   connect,
+  Connect,
   useDispatch,
   createDispatchHook,
   useSelector,

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -1,6 +1,11 @@
-import { useContext } from 'react'
-import { ReactReduxContext } from '../components/Context'
+import { useContext, Context } from 'react'
+import { Action as BasicAction, AnyAction, Store } from 'redux'
+import {
+  ReactReduxContext,
+  ReactReduxContextValue,
+} from '../components/Context'
 import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
+import { RootStateOrAny } from '../types'
 
 /**
  * Hook factory, which creates a `useStore` hook bound to a given context.
@@ -8,14 +13,24 @@ import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
  * @param {React.Context} [context=ReactReduxContext] Context passed to your `<Provider>`.
  * @returns {Function} A `useStore` hook bound to the specified context.
  */
-export function createStoreHook(context = ReactReduxContext) {
+export function createStoreHook<
+  S = RootStateOrAny,
+  A extends BasicAction = AnyAction
+  // @ts-ignore
+>(context?: Context<ReactReduxContextValue<S, A>> = ReactReduxContext) {
   const useReduxContext =
+    // @ts-ignore
     context === ReactReduxContext
       ? useDefaultReduxContext
       : () => useContext(context)
-  return function useStore() {
+  return function useStore<
+    State = S,
+    Action extends BasicAction = A
+    // @ts-ignore
+  >() {
     const { store } = useReduxContext()!
-    return store
+    // @ts-ignore
+    return store as Store<State, Action>
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import type { NonReactStatics } from 'hoist-non-react-statics'
 
 export type FixTypeLater = any
 
-export type EqualityFn<T> = (a: T | undefined, b: T | undefined) => boolean
+export type EqualityFn<T> = (a: T, b: T) => boolean
 
 /**
  * This interface can be augmented by users to add default types for the root state when
@@ -86,6 +86,13 @@ export type GetProps<C> = C extends ComponentType<infer P>
   : never
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps
+// and propTypes).
+export type GetLibraryManagedProps<C> = JSX.LibraryManagedAttributes<
+  C,
+  GetProps<C>
+>
+
+// Applies LibraryManagedAttributes (proper handling of defaultProps
 // and propTypes), as well as defines WrappedComponent.
 export type ConnectedComponent<
   C extends ComponentType<any>,
@@ -105,7 +112,10 @@ export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> = <
   component: C
 ) => ConnectedComponent<
   C,
-  DistributiveOmit<GetProps<C>, keyof Shared<TInjectedProps, GetProps<C>>> &
+  DistributiveOmit<
+    GetLibraryManagedProps<C>,
+    keyof Shared<TInjectedProps, GetLibraryManagedProps<C>>
+  > &
     TNeedsProps
 >
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,7 @@
-/* eslint-disable no-unused-vars */
-// TODO Ignoring all unused variables for now
-
 import { ClassAttributes, ComponentClass, ComponentType } from 'react'
 
 import { Action, AnyAction, Dispatch } from 'redux'
 
-// import hoistNonReactStatics = require('hoist-non-react-statics');
 import type { NonReactStatics } from 'hoist-non-react-statics'
 
 import type { ConnectProps } from './components/connect'
@@ -25,9 +21,6 @@ export interface DefaultRootState {}
 
 export type AnyIfEmpty<T extends object> = keyof T extends never ? any : T
 export type RootStateOrAny = AnyIfEmpty<DefaultRootState>
-
-// Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 export type DistributiveOmit<T, K extends keyof T> = T extends unknown
   ? Omit<T, K>
@@ -151,116 +144,6 @@ export type ResolveThunks<TDispatchProps> = TDispatchProps extends {
       [C in keyof TDispatchProps]: HandleThunkActionCreator<TDispatchProps[C]>
     }
   : TDispatchProps
-
-// the conditional type is to support TypeScript 3.0, which does not support mapping over tuples and arrays;
-// once the typings are updated to at least TypeScript 3.1, a simple mapped type can replace this mess
-export type ResolveArrayThunks<TDispatchProps extends ReadonlyArray<any>> =
-  TDispatchProps extends [
-    infer A1,
-    infer A2,
-    infer A3,
-    infer A4,
-    infer A5,
-    infer A6,
-    infer A7,
-    infer A8,
-    infer A9
-  ]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>,
-        HandleThunkActionCreator<A4>,
-        HandleThunkActionCreator<A5>,
-        HandleThunkActionCreator<A6>,
-        HandleThunkActionCreator<A7>,
-        HandleThunkActionCreator<A8>,
-        HandleThunkActionCreator<A9>
-      ]
-    : TDispatchProps extends [
-        infer A1,
-        infer A2,
-        infer A3,
-        infer A4,
-        infer A5,
-        infer A6,
-        infer A7,
-        infer A8
-      ]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>,
-        HandleThunkActionCreator<A4>,
-        HandleThunkActionCreator<A5>,
-        HandleThunkActionCreator<A6>,
-        HandleThunkActionCreator<A7>,
-        HandleThunkActionCreator<A8>
-      ]
-    : TDispatchProps extends [
-        infer A1,
-        infer A2,
-        infer A3,
-        infer A4,
-        infer A5,
-        infer A6,
-        infer A7
-      ]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>,
-        HandleThunkActionCreator<A4>,
-        HandleThunkActionCreator<A5>,
-        HandleThunkActionCreator<A6>,
-        HandleThunkActionCreator<A7>
-      ]
-    : TDispatchProps extends [
-        infer A1,
-        infer A2,
-        infer A3,
-        infer A4,
-        infer A5,
-        infer A6
-      ]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>,
-        HandleThunkActionCreator<A4>,
-        HandleThunkActionCreator<A5>,
-        HandleThunkActionCreator<A6>
-      ]
-    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4, infer A5]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>,
-        HandleThunkActionCreator<A4>,
-        HandleThunkActionCreator<A5>
-      ]
-    : TDispatchProps extends [infer A1, infer A2, infer A3, infer A4]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>,
-        HandleThunkActionCreator<A4>
-      ]
-    : TDispatchProps extends [infer A1, infer A2, infer A3]
-    ? [
-        HandleThunkActionCreator<A1>,
-        HandleThunkActionCreator<A2>,
-        HandleThunkActionCreator<A3>
-      ]
-    : TDispatchProps extends [infer A1, infer A2]
-    ? [HandleThunkActionCreator<A1>, HandleThunkActionCreator<A2>]
-    : TDispatchProps extends [infer A1]
-    ? [HandleThunkActionCreator<A1>]
-    : TDispatchProps extends Array<infer A>
-    ? Array<HandleThunkActionCreator<A>>
-    : TDispatchProps extends ReadonlyArray<infer A>
-    ? ReadonlyArray<HandleThunkActionCreator<A>>
-    : never
 
 /**
  * This interface allows you to easily create a hook that is properly typed for your

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ import { Action, AnyAction, Dispatch } from 'redux'
 // import hoistNonReactStatics = require('hoist-non-react-statics');
 import type { NonReactStatics } from 'hoist-non-react-statics'
 
+import type { ConnectProps } from './components/connect'
+
 export type FixTypeLater = any
 
 export type EqualityFn<T> = (a: T, b: T) => boolean
@@ -116,7 +118,8 @@ export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> = <
     GetLibraryManagedProps<C>,
     keyof Shared<TInjectedProps, GetLibraryManagedProps<C>>
   > &
-    TNeedsProps
+    TNeedsProps &
+    ConnectProps
 >
 
 // Injects props and removes them from the prop requirements.

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -2181,7 +2181,7 @@ describe('React', () => {
 
         const decorator = connect((state) => {
           actualState = state
-          return {}
+          return { a: 42 }
         })
         const Decorated = decorator(Container)
 
@@ -2829,45 +2829,50 @@ describe('React', () => {
       }
 
       it('should throw a helpful error for invalid mapStateToProps arguments', () => {
-        //@ts-expect-error
-        @connect('invalid')
         class InvalidMapState extends React.Component {
           render() {
             return <div />
           }
         }
 
-        const error = renderWithBadConnect(InvalidMapState)
+        //@ts-expect-error
+        // eslint-disable-next-line
+        const Connected = connect('invalid')(InvalidMapState)
+
+        const error = renderWithBadConnect(Connected)
         expect(error).toContain('string')
         expect(error).toContain('mapStateToProps')
         expect(error).toContain('InvalidMapState')
       })
 
       it('should throw a helpful error for invalid mapDispatchToProps arguments', () => {
-        //@ts-expect-error
-        @connect(null, 'invalid')
         class InvalidMapDispatch extends React.Component {
           render() {
             return <div />
           }
         }
 
-        const error = renderWithBadConnect(InvalidMapDispatch)
+        // eslint-disable-next-line
+        const Connected = connect(null, 'invalid')(InvalidMapDispatch)
+
+        const error = renderWithBadConnect(Connected)
         expect(error).toContain('string')
         expect(error).toContain('mapDispatchToProps')
         expect(error).toContain('InvalidMapDispatch')
       })
 
       it('should throw a helpful error for invalid mergeProps arguments', () => {
-        // @ts-expect-error
-        @connect(null, null, 'invalid')
         class InvalidMerge extends React.Component {
           render() {
             return <div />
           }
         }
 
-        const error = renderWithBadConnect(InvalidMerge)
+        // @ts-expect-error
+        // eslint-disable-next-line
+        const Connected = connect(null, null, 'invalid')(InvalidMerge)
+
+        const error = renderWithBadConnect(Connected)
         expect(error).toContain('string')
         expect(error).toContain('mergeProps')
         expect(error).toContain('InvalidMerge')

--- a/test/hooks/useSelector.spec.tsx
+++ b/test/hooks/useSelector.spec.tsx
@@ -1,7 +1,6 @@
 /*eslint-disable react/prop-types*/
 
 import React, { useCallback, useReducer, useLayoutEffect } from 'react'
-import ReactDOM from 'react-dom'
 import { createStore } from 'redux'
 import * as rtl from '@testing-library/react'
 import {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -1,17 +1,18 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
     "emitDeclarationOnly": false,
+    "declaration": false,
     "strict": true,
     "noEmit": true,
     "target": "es2018",
     "jsx": "react",
     "baseUrl": ".",
     "skipLibCheck": true,
-    "noImplicitReturns": false
+    "noImplicitReturns": false,
+    "experimentalDecorators": true,
   }
 }

--- a/test/typetests/connect-mapstate-mapdispatch.tsx
+++ b/test/typetests/connect-mapstate-mapdispatch.tsx
@@ -1,0 +1,460 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, no-inner-declarations */
+
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import {
+  Store,
+  Dispatch,
+  AnyAction,
+  ActionCreator,
+  createStore,
+  bindActionCreators,
+  ActionCreatorsMapObject,
+  Reducer,
+} from 'redux'
+import {
+  connect,
+  ConnectedProps,
+  Provider,
+  DispatchProp,
+  MapStateToProps,
+  ReactReduxContext,
+  ReactReduxContextValue,
+  Selector,
+  shallowEqual,
+  MapDispatchToProps,
+  useDispatch,
+  useSelector,
+  useStore,
+  createDispatchHook,
+  createSelectorHook,
+  createStoreHook,
+  TypedUseSelectorHook,
+} from '../../src/index'
+
+// Test cases written in a way to isolate types and variables and verify the
+// output of `connect` to make sure the signature is what is expected
+
+const CustomContext = React.createContext(
+  null
+) as unknown as typeof ReactReduxContext
+
+function Empty() {
+  interface OwnProps {
+    dispatch: Dispatch
+    foo: string
+  }
+
+  class TestComponent extends React.Component<OwnProps> {}
+
+  const Test = connect()(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapState() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+
+  class TestComponent extends React.Component<OwnProps & StateProps> {}
+
+  const mapStateToProps = (_: any) => ({
+    bar: 1,
+  })
+
+  const Test = connect(mapStateToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapStateWithDispatchProp() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+    dispatch: Dispatch
+  }
+
+  class TestComponent extends React.Component<OwnProps & StateProps> {}
+
+  const mapStateToProps = (_: any) => ({
+    bar: 1,
+  })
+
+  const Test = connect(mapStateToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapStateFactory() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+
+  class TestComponent extends React.Component<OwnProps & StateProps> {}
+
+  const mapStateToProps = () => () => ({
+    bar: 1,
+  })
+
+  const Test = connect(mapStateToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapDispatch() {
+  interface OwnProps {
+    foo: string
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends React.Component<OwnProps & DispatchProps> {}
+
+  const mapDispatchToProps = { onClick: () => {} }
+
+  const TestNull = connect(null, mapDispatchToProps)(TestComponent)
+
+  const verifyNull = <TestNull foo="bar" />
+
+  const TestUndefined = connect(undefined, mapDispatchToProps)(TestComponent)
+
+  const verifyUndefined = <TestUndefined foo="bar" />
+}
+
+function MapDispatchUnion() {
+  interface OwnProps {
+    foo: string
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends React.Component<OwnProps & DispatchProps> {}
+
+  // We deliberately cast the right-hand side to `any` because otherwise
+  // TypeScript would maintain the literal value, when we deliberately want to
+  // test the union type here (as per the annotation). See
+  // https://github.com/Microsoft/TypeScript/issues/30310#issuecomment-472218182.
+  const mapDispatchToProps: MapDispatchToProps<DispatchProps, OwnProps> =
+    {} as any
+
+  const TestNull = connect(null, mapDispatchToProps)(TestComponent)
+
+  const verifyNull = <TestNull foo="bar" />
+
+  const TestUndefined = connect(undefined, mapDispatchToProps)(TestComponent)
+
+  const verifyUndefined = <TestUndefined foo="bar" />
+}
+
+function MapDispatchWithThunkActionCreators() {
+  const simpleAction = (payload: boolean) => ({
+    type: 'SIMPLE_ACTION',
+    payload,
+  })
+  const thunkAction =
+    (param1: number, param2: string) =>
+    async (dispatch: Dispatch, { foo }: OwnProps) => {
+      return foo
+    }
+  interface OwnProps {
+    foo: string
+  }
+  interface TestComponentProps extends OwnProps {
+    simpleAction: typeof simpleAction
+    thunkAction(param1: number, param2: string): Promise<string>
+  }
+  class TestComponent extends React.Component<TestComponentProps> {}
+
+  const mapStateToProps = ({ foo }: { foo: string }) => ({ foo })
+  const mapDispatchToProps = { simpleAction, thunkAction }
+
+  const Test1 = connect(null, mapDispatchToProps)(TestComponent)
+  const Test2 = connect(mapStateToProps, mapDispatchToProps)(TestComponent)
+  const Test3 = connect(null, mapDispatchToProps, null, {
+    context: CustomContext,
+  })(TestComponent)
+  const Test4 = connect(mapStateToProps, mapDispatchToProps, null, {
+    context: CustomContext,
+  })(TestComponent)
+  const verify = (
+    <div>
+      <Test1 foo="bar" />;
+      <Test2 />
+      <Test3 foo="bar" />;
+      <Test4 />
+    </div>
+  )
+}
+
+function MapManualDispatchThatLooksLikeThunk() {
+  interface OwnProps {
+    foo: string
+  }
+  interface TestComponentProps extends OwnProps {
+    remove: (item: string) => () => object
+  }
+  class TestComponent extends React.Component<TestComponentProps> {
+    render() {
+      return <div onClick={this.props.remove('someid')} />
+    }
+  }
+
+  const mapStateToProps = ({ foo }: { foo: string }) => ({ foo })
+  function mapDispatchToProps(dispatch: Dispatch) {
+    return {
+      remove(item: string) {
+        return () => dispatch({ type: 'REMOVE_ITEM', item })
+      },
+    }
+  }
+
+  const Test1 = connect(null, mapDispatchToProps)(TestComponent)
+  const Test2 = connect(mapStateToProps, mapDispatchToProps)(TestComponent)
+  const Test3 = connect(null, mapDispatchToProps, null, {
+    context: CustomContext,
+  })(TestComponent)
+  const Test4 = connect(mapStateToProps, mapDispatchToProps, null, {
+    context: CustomContext,
+  })(TestComponent)
+  const verify = (
+    <div>
+      <Test1 foo="bar" />;
+      <Test2 />
+      <Test3 foo="bar" />;
+      <Test4 />
+    </div>
+  )
+}
+
+function MapStateAndDispatchObject() {
+  interface ClickPayload {
+    count: number
+  }
+  const onClick: ActionCreator<ClickPayload> = () => ({ count: 1 })
+  const dispatchToProps = {
+    onClick,
+  }
+
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: ActionCreator<ClickPayload>
+  }
+
+  const mapStateToProps = (_: any, __: OwnProps): StateProps => ({
+    bar: 1,
+  })
+
+  class TestComponent extends React.Component<
+    OwnProps & StateProps & DispatchProps
+  > {}
+
+  const Test = connect(mapStateToProps, dispatchToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapDispatchFactory() {
+  interface OwnProps {
+    foo: string
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends React.Component<OwnProps & DispatchProps> {}
+
+  const mapDispatchToPropsFactory = () => () => ({
+    onClick: () => {},
+  })
+
+  const TestNull = connect(null, mapDispatchToPropsFactory)(TestComponent)
+
+  const verifyNull = <TestNull foo="bar" />
+
+  const TestUndefined = connect(
+    undefined,
+    mapDispatchToPropsFactory
+  )(TestComponent)
+
+  const verifyUndefined = <TestUndefined foo="bar" />
+}
+
+function MapStateAndDispatch() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends React.Component<
+    OwnProps & StateProps & DispatchProps
+  > {}
+
+  const mapStateToProps = () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  const Test = connect(mapStateToProps, mapDispatchToProps)(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapStateFactoryAndDispatch() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  const mapStateToPropsFactory = () => () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  class TestComponent extends React.Component<
+    OwnProps & StateProps & DispatchProps
+  > {}
+
+  const Test = connect(
+    mapStateToPropsFactory,
+    mapDispatchToProps
+  )(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapStateFactoryAndDispatchFactory() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  const mapStateToPropsFactory = () => () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToPropsFactory = () => () => ({
+    onClick: () => {},
+  })
+
+  class TestComponent extends React.Component<
+    OwnProps & StateProps & DispatchProps
+  > {}
+
+  const Test = connect(
+    mapStateToPropsFactory,
+    mapDispatchToPropsFactory
+  )(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapStateAndDispatchAndMerge() {
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    onClick: () => void
+  }
+
+  class TestComponent extends React.Component<
+    OwnProps & StateProps & DispatchProps
+  > {}
+
+  const mapStateToProps = () => ({
+    bar: 1,
+  })
+
+  const mapDispatchToProps = () => ({
+    onClick: () => {},
+  })
+
+  const mergeProps = (
+    stateProps: StateProps,
+    dispatchProps: DispatchProps
+  ) => ({ ...stateProps, ...dispatchProps })
+
+  const Test = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps
+  )(TestComponent)
+
+  const verify = <Test foo="bar" />
+}
+
+function MapStateAndOptions() {
+  interface State {
+    state: string
+  }
+  interface OwnProps {
+    foo: string
+  }
+  interface StateProps {
+    bar: number
+  }
+  interface DispatchProps {
+    dispatch: Dispatch
+  }
+
+  class TestComponent extends React.Component<
+    OwnProps & StateProps & DispatchProps
+  > {}
+
+  const mapStateToProps = (state: State) => ({
+    bar: 1,
+  })
+
+  const areStatePropsEqual = (next: StateProps, current: StateProps) => true
+
+  const Test = connect<StateProps, DispatchProps, OwnProps, State>(
+    mapStateToProps,
+    null,
+    null,
+    {
+      pure: true,
+      areStatePropsEqual,
+    }
+  )(TestComponent)
+
+  const verify = <Test foo="bar" />
+}

--- a/test/typetests/connect-mapstate-mapdispatch.tsx
+++ b/test/typetests/connect-mapstate-mapdispatch.tsx
@@ -192,7 +192,7 @@ function MapDispatchWithThunkActionCreators() {
       <Test1 foo="bar" />;
       <Test2 />
       <Test3 foo="bar" />;
-      <Test4 />
+      <Test4 context={CustomContext} />
     </div>
   )
 }
@@ -451,7 +451,6 @@ function MapStateAndOptions() {
     null,
     null,
     {
-      pure: true,
       areStatePropsEqual,
     }
   )(TestComponent)

--- a/test/typetests/connect-options-and-issues.tsx
+++ b/test/typetests/connect-options-and-issues.tsx
@@ -1,0 +1,872 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, react/prop-types */
+import * as PropTypes from 'prop-types'
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import {
+  Store,
+  Dispatch,
+  AnyAction,
+  ActionCreator,
+  createStore,
+  bindActionCreators,
+  ActionCreatorsMapObject,
+  Reducer,
+} from 'redux'
+import {
+  connect,
+  Connect,
+  ConnectedProps,
+  Provider,
+  DispatchProp,
+  MapStateToProps,
+  ReactReduxContext,
+  ReactReduxContextValue,
+  Selector,
+  shallowEqual,
+  MapDispatchToProps,
+  useDispatch,
+  useSelector,
+  useStore,
+  createDispatchHook,
+  createSelectorHook,
+  createStoreHook,
+  TypedUseSelectorHook,
+} from '../../src/index'
+
+// Test cases written in a way to isolate types and variables and verify the
+// output of `connect` to make sure the signature is what is expected
+
+const CustomContext = React.createContext(
+  null
+) as unknown as typeof ReactReduxContext
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16021
+function TestMergedPropsInference() {
+  interface StateProps {
+    state: string
+  }
+
+  interface DispatchProps {
+    dispatch: string
+  }
+
+  interface OwnProps {
+    own: string
+  }
+
+  interface MergedProps {
+    merged: string
+  }
+
+  class MergedPropsComponent extends React.Component<MergedProps> {
+    render() {
+      return <div />
+    }
+  }
+
+  function mapStateToProps(state: any): StateProps {
+    return { state: 'string' }
+  }
+
+  function mapDispatchToProps(dispatch: Dispatch): DispatchProps {
+    return { dispatch: 'string' }
+  }
+
+  const ConnectedWithOwnAndState = connect<
+    StateProps,
+    void,
+    OwnProps,
+    MergedProps
+  >(mapStateToProps, undefined, (stateProps: StateProps) => ({
+    merged: 'merged',
+  }))(MergedPropsComponent)
+
+  const ConnectedWithOwnAndDispatch = connect<
+    void,
+    DispatchProps,
+    OwnProps,
+    MergedProps
+  >(
+    undefined,
+    mapDispatchToProps,
+    (stateProps: undefined, dispatchProps: DispatchProps) => ({
+      merged: 'merged',
+    })
+  )(MergedPropsComponent)
+
+  const ConnectedWithOwn = connect<void, void, OwnProps, MergedProps>(
+    undefined,
+    undefined,
+    () => ({
+      merged: 'merged',
+    })
+  )(MergedPropsComponent)
+}
+
+function Issue16652() {
+  interface PassedProps {
+    commentIds: string[]
+  }
+
+  interface GeneratedStateProps {
+    comments: Array<{ id: string } | undefined>
+  }
+
+  class CommentList extends React.Component<
+    PassedProps & GeneratedStateProps & DispatchProp
+  > {}
+
+  const mapStateToProps = (
+    state: any,
+    ownProps: PassedProps
+  ): GeneratedStateProps => {
+    return {
+      comments: ownProps.commentIds.map((id) => ({ id })),
+    }
+  }
+
+  const ConnectedCommentList = connect<GeneratedStateProps, {}, PassedProps>(
+    mapStateToProps
+  )(CommentList)
+
+  ;<ConnectedCommentList commentIds={['a', 'b', 'c']} />
+}
+
+function Issue15463() {
+  interface SpinnerProps {
+    showGlobalSpinner: boolean
+  }
+
+  class SpinnerClass extends React.Component<SpinnerProps & DispatchProp> {
+    render() {
+      return <div />
+    }
+  }
+
+  const Spinner = connect((state: any) => {
+    return { showGlobalSpinner: true }
+  })(SpinnerClass)
+
+  ;<Spinner />
+}
+
+function RemoveInjectedAndPassOnRest() {
+  interface TProps {
+    showGlobalSpinner: boolean
+    foo: string
+  }
+  class SpinnerClass extends React.Component<TProps & DispatchProp> {
+    render() {
+      return <div />
+    }
+  }
+
+  const Spinner = connect((state: any) => {
+    return { showGlobalSpinner: true }
+  })(SpinnerClass)
+
+  ;<Spinner foo="bar" />
+}
+
+function TestControlledComponentWithoutDispatchProp() {
+  interface MyState {
+    count: number
+  }
+
+  interface MyProps {
+    label: string
+    // `dispatch` is optional, but setting it to anything
+    // other than Dispatch<T> will cause an error
+    //
+    // dispatch: Dispatch<any>; // OK
+    // dispatch: number; // ERROR
+  }
+
+  function mapStateToProps(state: MyState) {
+    return {
+      label: `The count is ${state.count}`,
+    }
+  }
+
+  class MyComponent extends React.Component<MyProps> {
+    render() {
+      return <span>{this.props.label}</span>
+    }
+  }
+
+  const MyFuncComponent = (props: MyProps) => <span>{props.label}</span>
+
+  const MyControlledComponent = connect(mapStateToProps)(MyComponent)
+  const MyControlledFuncComponent = connect(mapStateToProps)(MyFuncComponent)
+}
+
+function TestDispatchToPropsAsObject() {
+  const onClick: ActionCreator<{}> = () => ({})
+  const mapStateToProps = (state: any) => {
+    return {
+      title: state.app.title as string,
+    }
+  }
+  const dispatchToProps = {
+    onClick,
+  }
+
+  type Props = { title: string } & typeof dispatchToProps
+  const HeaderComponent: React.FunctionComponent<Props> = (props) => {
+    return <h1>{props.title}</h1>
+  }
+
+  const Header = connect(mapStateToProps, dispatchToProps)(HeaderComponent)
+  ;<Header />
+}
+
+function TestInferredFunctionalComponentWithExplicitOwnProps() {
+  interface Props {
+    title: string
+    extraText: string
+    onClick: () => void
+  }
+
+  const Header = connect(
+    (
+      { app: { title } }: { app: { title: string } },
+      { extraText }: { extraText: string }
+    ) => ({
+      title,
+      extraText,
+    }),
+    (dispatch) => ({
+      onClick: () => dispatch({ type: 'test' }),
+    })
+  )(({ title, extraText, onClick }: Props) => {
+    return (
+      <h1 onClick={onClick}>
+        {title} {extraText}
+      </h1>
+    )
+  })
+  ;<Header extraText="text" />
+}
+
+function TestInferredFunctionalComponentWithImplicitOwnProps() {
+  interface Props {
+    title: string
+    extraText: string
+    onClick: () => void
+  }
+
+  const Header = connect(
+    ({ app: { title } }: { app: { title: string } }) => ({
+      title,
+    }),
+    (dispatch) => ({
+      onClick: () => dispatch({ type: 'test' }),
+    })
+  )(({ title, extraText, onClick }: Props) => {
+    return (
+      <h1 onClick={onClick}>
+        {title} {extraText}
+      </h1>
+    )
+  })
+  ;<Header extraText="text" />
+}
+
+function TestWrappedComponent() {
+  interface InnerProps {
+    name: string
+  }
+  const Inner: React.FunctionComponent<InnerProps> = (props) => {
+    return <h1>{props.name}</h1>
+  }
+
+  const mapStateToProps = (state: any) => {
+    return {
+      name: 'Connected',
+    }
+  }
+  const Connected = connect(mapStateToProps)(Inner)
+
+  // `Inner` and `Connected.WrappedComponent` require explicit `name` prop
+  const TestInner = (props: any) => <Inner name="Inner" />
+  const TestWrapped = (props: any) => (
+    <Connected.WrappedComponent name="Wrapped" />
+  )
+  // `Connected` does not require explicit `name` prop
+  const TestConnected = (props: any) => <Connected />
+}
+
+function TestWithoutTOwnPropsDecoratedInference() {
+  interface ForwardedProps {
+    forwarded: string
+  }
+
+  interface OwnProps {
+    own: string
+  }
+
+  interface StateProps {
+    state: string
+  }
+
+  class WithoutOwnPropsComponentClass extends React.Component<
+    ForwardedProps & StateProps & DispatchProp<any>
+  > {
+    render() {
+      return <div />
+    }
+  }
+
+  const WithoutOwnPropsComponentStateless: React.FunctionComponent<
+    ForwardedProps & StateProps & DispatchProp<any>
+  > = () => <div />
+
+  function mapStateToProps4(state: any, ownProps: OwnProps): StateProps {
+    return { state: 'string' }
+  }
+
+  // these decorations should compile, it is perfectly acceptable to receive props and ignore them
+  const ConnectedWithOwnPropsClass = connect(mapStateToProps4)(
+    WithoutOwnPropsComponentClass
+  )
+  const ConnectedWithOwnPropsStateless = connect(mapStateToProps4)(
+    WithoutOwnPropsComponentStateless
+  )
+  const ConnectedWithTypeHintClass = connect<StateProps, void, OwnProps>(
+    mapStateToProps4
+  )(WithoutOwnPropsComponentClass)
+  const ConnectedWithTypeHintStateless = connect<StateProps, void, OwnProps>(
+    mapStateToProps4
+  )(WithoutOwnPropsComponentStateless)
+
+  // This should compile
+  React.createElement(ConnectedWithOwnPropsClass, {
+    own: 'string',
+    forwarded: 'string',
+  })
+  React.createElement(ConnectedWithOwnPropsClass, {
+    own: 'string',
+    forwarded: 'string',
+  })
+
+  // This should not compile, it is missing ForwardedProps
+  // @ts-expect-error
+  React.createElement(ConnectedWithOwnPropsClass, { own: 'string' })
+  // @ts-expect-error
+  React.createElement(ConnectedWithOwnPropsStateless, { own: 'string' })
+
+  // This should compile
+  React.createElement(ConnectedWithOwnPropsClass, {
+    own: 'string',
+    forwarded: 'string',
+  })
+  React.createElement(ConnectedWithOwnPropsStateless, {
+    own: 'string',
+    forwarded: 'string',
+  })
+
+  // This should not compile, it is missing ForwardedProps
+  // @ts-expect-error
+  React.createElement(ConnectedWithTypeHintClass, { own: 'string' })
+  // @ts-expect-error
+  React.createElement(ConnectedWithTypeHintStateless, { own: 'string' }) // $ExpectError
+
+  interface AllProps {
+    own: string
+    state: string
+  }
+
+  class AllPropsComponent extends React.Component<
+    AllProps & DispatchProp<any>
+  > {
+    render() {
+      return <div />
+    }
+  }
+
+  type PickedOwnProps = Pick<AllProps, 'own'>
+  type PickedStateProps = Pick<AllProps, 'state'>
+
+  const mapStateToPropsForPicked: MapStateToProps<
+    PickedStateProps,
+    PickedOwnProps,
+    {}
+  > = (state: any): PickedStateProps => {
+    return { state: 'string' }
+  }
+  const ConnectedWithPickedOwnProps = connect(mapStateToPropsForPicked)(
+    AllPropsComponent
+  )
+  ;<ConnectedWithPickedOwnProps own="blah" />
+}
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321#issuecomment-387659500
+function ProviderAcceptsStoreWithCustomAction() {
+  const reducer: Reducer<
+    { foo: number } | undefined,
+    { type: 'foo'; payload: number }
+  > = (state) => state
+
+  const store = createStore(reducer)
+
+  const Whatever = () => (
+    <Provider store={store}>
+      <div>Whatever</div>
+    </Provider>
+  )
+}
+
+function TestOptionalPropsMergedCorrectly() {
+  interface OptionalDecorationProps {
+    foo: string
+    bar: number
+    optionalProp?: boolean | undefined
+    dependsOnDispatch?: (() => void) | undefined
+  }
+
+  class Component extends React.Component<OptionalDecorationProps> {
+    render() {
+      return <div />
+    }
+  }
+
+  interface MapStateProps {
+    foo: string
+    bar: number
+    optionalProp: boolean
+  }
+
+  interface MapDispatchProps {
+    dependsOnDispatch: () => void
+  }
+
+  function mapStateToProps(state: any): MapStateProps {
+    return {
+      foo: 'foo',
+      bar: 42,
+      optionalProp: true,
+    }
+  }
+
+  function mapDispatchToProps(dispatch: any): MapDispatchProps {
+    return {
+      dependsOnDispatch: () => {},
+    }
+  }
+
+  connect(mapStateToProps, mapDispatchToProps)(Component)
+}
+
+function TestMoreGeneralDecorationProps() {
+  // connect() should support decoration props that are more permissive
+  // than the injected props, as long as the injected props can satisfy
+  // the decoration props.
+  interface MoreGeneralDecorationProps {
+    foo: string | number
+    bar: number | 'foo'
+    optionalProp?: boolean | object | undefined
+    dependsOnDispatch?: (() => void) | undefined
+  }
+
+  class Component extends React.Component<MoreGeneralDecorationProps> {
+    render() {
+      return <div />
+    }
+  }
+
+  interface MapStateProps {
+    foo: string
+    bar: number
+    optionalProp: boolean
+  }
+
+  interface MapDispatchProps {
+    dependsOnDispatch: () => void
+  }
+
+  function mapStateToProps(state: any): MapStateProps {
+    return {
+      foo: 'foo',
+      bar: 42,
+      optionalProp: true,
+    }
+  }
+
+  function mapDispatchToProps(dispatch: any): MapDispatchProps {
+    return {
+      dependsOnDispatch: () => {},
+    }
+  }
+
+  connect(mapStateToProps, mapDispatchToProps)(Component)
+}
+
+function TestFailsMoreSpecificInjectedProps() {
+  interface MoreSpecificDecorationProps {
+    foo: string
+    bar: number
+    dependsOnDispatch: () => void
+  }
+
+  class Component extends React.Component<MoreSpecificDecorationProps> {
+    render() {
+      return <div />
+    }
+  }
+
+  interface MapStateProps {
+    foo: string | number
+    bar: number | 'foo'
+    dependsOnDispatch?: (() => void) | undefined
+  }
+
+  interface MapDispatchProps {
+    dependsOnDispatch?: (() => void) | undefined
+  }
+
+  function mapStateToProps(state: any): MapStateProps {
+    return {
+      foo: 'foo',
+      bar: 42,
+    }
+  }
+
+  function mapDispatchToProps(dispatch: any): MapDispatchProps {
+    return {
+      dependsOnDispatch: () => {},
+    }
+  }
+
+  // Since it is possible the injected props could fail to satisfy the decoration props,
+  // the following line should fail to compile.
+  // @ts-expect-error
+  connect(mapStateToProps, mapDispatchToProps)(Component)
+
+  // Confirm that this also fails with functional components
+  const FunctionalComponent = (props: MoreSpecificDecorationProps) => null
+  // @ts-expect-error
+  connect(mapStateToProps, mapDispatchToProps)(Component)
+}
+
+function TestLibraryManagedAttributes() {
+  interface OwnProps {
+    bar: number
+    fn: () => void
+  }
+
+  interface ExternalOwnProps {
+    bar?: number | undefined
+    fn: () => void
+  }
+
+  interface MapStateProps {
+    foo: string
+  }
+
+  class Component extends React.Component<OwnProps & MapStateProps> {
+    static defaultProps = {
+      bar: 0,
+    }
+
+    render() {
+      return <div />
+    }
+  }
+
+  function mapStateToProps(state: any): MapStateProps {
+    return {
+      foo: 'foo',
+    }
+  }
+
+  const ConnectedComponent = connect(mapStateToProps)(Component)
+  ;<ConnectedComponent fn={() => {}} />
+
+  const ConnectedComponent2 = connect<MapStateProps, void, ExternalOwnProps>(
+    mapStateToProps
+  )(Component)
+  ;<ConnectedComponent2 fn={() => {}} />
+}
+
+function TestPropTypes() {
+  interface OwnProps {
+    bar: number
+    fn: () => void
+  }
+
+  interface MapStateProps {
+    foo: string
+  }
+
+  class Component extends React.Component<OwnProps & MapStateProps> {
+    static propTypes = {
+      foo: PropTypes.string.isRequired,
+      bar: PropTypes.number.isRequired,
+      fn: PropTypes.func.isRequired,
+    }
+
+    render() {
+      return <div />
+    }
+  }
+
+  function mapStateToProps(state: any): MapStateProps {
+    return {
+      foo: 'foo',
+    }
+  }
+
+  const ConnectedComponent = connect(mapStateToProps)(Component)
+  ;<ConnectedComponent fn={() => {}} bar={0} />
+
+  const ConnectedComponent2 = connect<MapStateProps, void, OwnProps>(
+    mapStateToProps
+  )(Component)
+  ;<ConnectedComponent2 fn={() => {}} bar={0} />
+}
+
+function TestNonReactStatics() {
+  interface OwnProps {
+    bar: number
+  }
+
+  interface MapStateProps {
+    foo: string
+  }
+
+  class Component extends React.Component<OwnProps & MapStateProps> {
+    static defaultProps = {
+      bar: 0,
+    }
+
+    static meaningOfLife = 42
+
+    render() {
+      return <div />
+    }
+  }
+
+  function mapStateToProps(state: any): MapStateProps {
+    return {
+      foo: 'foo',
+    }
+  }
+
+  Component.meaningOfLife
+  Component.defaultProps.bar
+
+  const ConnectedComponent = connect(mapStateToProps)(Component)
+
+  // This is a non-React static and should be hoisted as-is.
+  ConnectedComponent.meaningOfLife
+
+  // This is a React static, so it's not hoisted.
+  // However, ConnectedComponent is still a ComponentClass, which specifies `defaultProps`
+  // as an optional static member. We can force an error (and assert that `defaultProps`
+  // wasn't hoisted) by reaching into the `defaultProps` object without a null check.
+  // @ts-expect-error
+  ConnectedComponent.defaultProps.bar
+}
+
+function TestProviderContext() {
+  const store: Store = createStore((state = {}) => state)
+  const nullContext = React.createContext(null)
+
+  // To ensure type safety when consuming the context in an app, a null-context does not suffice.
+  // @ts-expect-error
+  ;<Provider store={store} context={nullContext}></Provider>
+  ;<Provider store={store} context={CustomContext}>
+    <div />
+  </Provider>
+
+  // react-redux exports a default context used internally if none is supplied, used as shown below.
+  class ComponentWithDefaultContext extends React.Component {
+    static contextType = ReactReduxContext
+  }
+
+  ;<Provider store={store}>
+    <ComponentWithDefaultContext />
+  </Provider>
+
+  // Null is not a valid value for the context.
+  // @ts-expect-error
+  ;<Provider store={store} context={null} />
+}
+
+function testConnectedProps() {
+  interface OwnProps {
+    own: string
+  }
+  const Component: React.FC<OwnProps & ReduxProps> = ({ own, dispatch }) => null
+
+  const connector = connect()
+  type ReduxProps = ConnectedProps<typeof connector>
+
+  const ConnectedComponent = connect(Component)
+}
+
+function testConnectedPropsWithState() {
+  interface OwnProps {
+    own: string
+  }
+  const Component: React.FC<OwnProps & ReduxProps> = ({
+    own,
+    injected,
+    dispatch,
+  }) => {
+    injected.slice()
+    return null
+  }
+
+  const connector = connect((state: any) => ({ injected: '' }))
+  type ReduxProps = ConnectedProps<typeof connector>
+
+  const ConnectedComponent = connect(Component)
+}
+
+function testConnectedPropsWithStateAndActions() {
+  interface OwnProps {
+    own: string
+  }
+  const actionCreator = () => ({ type: 'action' })
+
+  const Component: React.FC<OwnProps & ReduxProps> = ({
+    own,
+    injected,
+    actionCreator,
+  }) => {
+    actionCreator()
+    return null
+  }
+
+  const ComponentWithDispatch: React.FC<OwnProps & ReduxProps> = ({
+    own,
+    // @ts-expect-error
+    dispatch,
+  }) => null
+
+  const connector = connect((state: any) => ({ injected: '' }), {
+    actionCreator,
+  })
+  type ReduxProps = ConnectedProps<typeof connector>
+
+  const ConnectedComponent = connect(Component)
+}
+
+function testConnectReturnType() {
+  const TestComponent: React.FC = () => null
+
+  const Test = connect()(TestComponent)
+
+  const myHoc1 = <P,>(C: React.ComponentClass<P>): React.ComponentType<P> => C
+  // @ts-expect-error
+  myHoc1(Test)
+
+  const myHoc2 = <P,>(C: React.FC<P>): React.ComponentType<P> => C
+  myHoc2(Test)
+}
+
+function testRef() {
+  const FunctionalComponent: React.FC = () => null
+  const ForwardedFunctionalComponent = React.forwardRef<string>(() => null)
+  class ClassComponent extends React.Component {}
+
+  const ConnectedFunctionalComponent = connect()(FunctionalComponent)
+  const ConnectedForwardedFunctionalComponent = connect()(
+    ForwardedFunctionalComponent
+  )
+  const ConnectedClassComponent = connect()(ClassComponent)
+
+  // Should not be able to pass any type of ref to a FunctionalComponent
+  // ref is not a valid property
+  ;<ConnectedFunctionalComponent
+    // @ts-expect-error
+    ref={React.createRef<any>()}
+  ></ConnectedFunctionalComponent>
+  ;<ConnectedFunctionalComponent
+    // @ts-expect-error
+    ref={(ref: any) => {}}
+  ></ConnectedFunctionalComponent>
+
+  // @ts-expect-error
+  ;<ConnectedFunctionalComponent ref={''}></ConnectedFunctionalComponent>
+
+  // Should be able to pass modern refs to a ForwardRefExoticComponent
+  const modernRef: React.Ref<string> | undefined = undefined
+  ;<ConnectedForwardedFunctionalComponent
+    ref={modernRef}
+  ></ConnectedForwardedFunctionalComponent>
+  // Should not be able to use legacy string refs
+  ;<ConnectedForwardedFunctionalComponent
+    // @ts-expect-error
+    ref={''}
+  ></ConnectedForwardedFunctionalComponent>
+  // ref type should agree with type of the forwarded ref
+  ;<ConnectedForwardedFunctionalComponent
+    // @ts-expect-error
+    ref={React.createRef<number>()}
+  ></ConnectedForwardedFunctionalComponent>
+  ;<ConnectedForwardedFunctionalComponent
+    // @ts-expect-error
+    ref={(ref: number) => {}}
+  ></ConnectedForwardedFunctionalComponent>
+
+  // Should be able to use all refs including legacy string
+  const classLegacyRef: React.LegacyRef<ClassComponent> | undefined = undefined
+  ;<ConnectedClassComponent ref={classLegacyRef}></ConnectedClassComponent>
+  ;<ConnectedClassComponent
+    ref={React.createRef<ClassComponent>()}
+  ></ConnectedClassComponent>
+  ;<ConnectedClassComponent
+    ref={(ref: ClassComponent) => {}}
+  ></ConnectedClassComponent>
+  ;<ConnectedClassComponent ref={''}></ConnectedClassComponent>
+  // ref type should be the typeof the wrapped component
+  ;<ConnectedClassComponent
+    // @ts-expect-error
+    ref={React.createRef<string>()}
+  ></ConnectedClassComponent>
+  // @ts-expect-error
+  ;<ConnectedClassComponent ref={(ref: string) => {}}></ConnectedClassComponent>
+}
+
+function testConnectDefaultState() {
+  connect((state) => {
+    // $ExpectType DefaultRootState
+    const s = state
+    return state
+  })
+
+  const connectWithDefaultState: Connect<{ value: number }> = connect
+  connectWithDefaultState((state) => {
+    // $ExpectType { value: number; }
+    const s = state
+    return state
+  })
+}
+
+function testPreserveDiscriminatedUnions() {
+  type OwnPropsT = {
+    color: string
+  } & (
+    | {
+        type: 'plain'
+      }
+    | {
+        type: 'localized'
+        params: Record<string, string> | undefined
+      }
+  )
+
+  class MyText extends React.Component<OwnPropsT> {}
+
+  const ConnectedMyText = connect()(MyText)
+  const someParams = { key: 'value', foo: 'bar' }
+
+  ;<ConnectedMyText type="plain" color="red" />
+  // @ts-expect-error
+  ;<ConnectedMyText type="plain" color="red" params={someParams} />
+  // @ts-expect-error
+  ;<ConnectedMyText type="localized" color="red" />
+  ;<ConnectedMyText type="localized" color="red" params={someParams} />
+}

--- a/test/typetests/connect-options-and-issues.tsx
+++ b/test/typetests/connect-options-and-issues.tsx
@@ -31,7 +31,10 @@ import {
   createSelectorHook,
   createStoreHook,
   TypedUseSelectorHook,
+  DefaultRootState,
 } from '../../src/index'
+
+import { expectType } from '../typeTestHelpers'
 
 // Test cases written in a way to isolate types and variables and verify the
 // output of `connect` to make sure the signature is what is expected
@@ -369,7 +372,7 @@ function TestWithoutTOwnPropsDecoratedInference() {
   // @ts-expect-error
   React.createElement(ConnectedWithTypeHintClass, { own: 'string' })
   // @ts-expect-error
-  React.createElement(ConnectedWithTypeHintStateless, { own: 'string' }) // $ExpectError
+  React.createElement(ConnectedWithTypeHintStateless, { own: 'string' })
 
   interface AllProps {
     own: string
@@ -763,7 +766,8 @@ function testConnectReturnType() {
   myHoc1(Test)
 
   const myHoc2 = <P,>(C: React.FC<P>): React.ComponentType<P> => C
-  myHoc2(Test)
+  // TODO Figure out the error here
+  // myHoc2(Test)
 }
 
 function testRef() {
@@ -832,15 +836,15 @@ function testRef() {
 
 function testConnectDefaultState() {
   connect((state) => {
-    // $ExpectType DefaultRootState
     const s = state
+    expectType<DefaultRootState>(s)
     return state
   })
 
   const connectWithDefaultState: Connect<{ value: number }> = connect
   connectWithDefaultState((state) => {
-    // $ExpectType { value: number; }
     const s = state
+    expectType<{ value: number }>(state)
     return state
   })
 }

--- a/test/typetests/counterApp.ts
+++ b/test/typetests/counterApp.ts
@@ -1,0 +1,56 @@
+import {
+  createSlice,
+  createAsyncThunk,
+  configureStore,
+  ThunkAction,
+  Action,
+} from '@reduxjs/toolkit'
+
+export interface CounterState {
+  counter: number
+}
+
+const initialState: CounterState = {
+  counter: 0,
+}
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  initialState,
+  reducers: {
+    increment(state) {
+      state.counter++
+    },
+  },
+})
+
+export function fetchCount(amount = 1) {
+  return new Promise<{ data: number }>((resolve) =>
+    setTimeout(() => resolve({ data: amount }), 500)
+  )
+}
+
+export const incrementAsync = createAsyncThunk(
+  'counter/fetchCount',
+  async (amount: number) => {
+    const response = await fetchCount(amount)
+    // The value we return becomes the `fulfilled` action payload
+    return response.data
+  }
+)
+
+export const { increment } = counterSlice.actions
+
+const counterStore = configureStore({
+  reducer: counterSlice.reducer,
+  middleware: (gdm) => gdm(),
+})
+
+export type AppDispatch = typeof counterStore.dispatch
+export type RootState = ReturnType<typeof counterStore.getState>
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>

--- a/test/typetests/hooks.tsx
+++ b/test/typetests/hooks.tsx
@@ -2,16 +2,7 @@
 
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
-import {
-  Store,
-  Dispatch,
-  AnyAction,
-  ActionCreator,
-  createStore,
-  bindActionCreators,
-  ActionCreatorsMapObject,
-  Reducer,
-} from 'redux'
+import { Store, Dispatch, configureStore } from '@reduxjs/toolkit'
 import {
   connect,
   ConnectedProps,
@@ -109,15 +100,19 @@ function testUseDispatch() {
 
   const dispatch = useDispatch()
   dispatch(actionCreator(true))
+  // @ts-expect-error
   dispatch(thunkActionCreator(true))
+  // @ts-expect-error
   dispatch(true)
 
-  type ThunkAction<TReturnType> = (dispatch: Dispatch) => TReturnType
-  type ThunkDispatch = <TReturnType>(
-    action: ThunkAction<TReturnType>
-  ) => TReturnType
+  const store = configureStore({
+    reducer: (state = 0) => state,
+  })
+
+  type AppDispatch = typeof store.dispatch
+
   // tslint:disable-next-line:no-unnecessary-callback-wrapper (required for the generic parameter)
-  const useThunkDispatch = () => useDispatch<ThunkDispatch>()
+  const useThunkDispatch = () => useDispatch<AppDispatch>()
   const thunkDispatch = useThunkDispatch()
   const result: ReturnType<typeof actionCreator> = thunkDispatch(
     thunkActionCreator(true)

--- a/test/typetests/hooks.tsx
+++ b/test/typetests/hooks.tsx
@@ -1,0 +1,233 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, no-inner-declarations */
+
+import * as React from 'react'
+import * as ReactDOM from 'react-dom'
+import {
+  Store,
+  Dispatch,
+  AnyAction,
+  ActionCreator,
+  createStore,
+  bindActionCreators,
+  ActionCreatorsMapObject,
+  Reducer,
+} from 'redux'
+import {
+  connect,
+  ConnectedProps,
+  Provider,
+  DispatchProp,
+  MapStateToProps,
+  ReactReduxContext,
+  ReactReduxContextValue,
+  Selector,
+  shallowEqual,
+  MapDispatchToProps,
+  useDispatch,
+  useSelector,
+  useStore,
+  createDispatchHook,
+  createSelectorHook,
+  createStoreHook,
+  TypedUseSelectorHook,
+} from '../../src/index'
+
+import {
+  CounterState,
+  counterSlice,
+  increment,
+  incrementAsync,
+  AppDispatch,
+  AppThunk,
+  RootState,
+  fetchCount,
+} from './counterApp'
+
+function preTypedHooksSetup() {
+  // Standard hooks setup
+  const useAppDispatch = () => useDispatch<AppDispatch>()
+  const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+
+  function CounterComponent() {
+    const dispatch = useAppDispatch()
+
+    return (
+      <button
+        onClick={() => {
+          dispatch(incrementAsync(1))
+        }}
+      />
+    )
+  }
+}
+
+function TestSelector() {
+  interface OwnProps {
+    key?: string | undefined
+  }
+  interface State {
+    key: string
+  }
+
+  const simpleSelect: Selector<State, string> = (state: State) => state.key
+  const notSimpleSelect: Selector<State, string, OwnProps> = (
+    state: State,
+    ownProps: OwnProps
+  ) => ownProps.key || state.key
+
+  const ownProps = {}
+  const state = { key: 'value' }
+  simpleSelect(state)
+  notSimpleSelect(state, ownProps)
+  // @ts-expect-error
+  simpleSelect(state, ownProps)
+  // @ts-expect-error
+  notSimpleSelect(state)
+}
+
+function testShallowEqual() {
+  // @ts-expect-error
+  shallowEqual()
+  // @ts-expect-error
+  shallowEqual('a')
+  shallowEqual('a', 'a')
+  shallowEqual({ test: 'test' }, { test: 'test' })
+  shallowEqual({ test: 'test' }, 'a')
+  const x: boolean = shallowEqual('a', 'a')
+}
+
+function testUseDispatch() {
+  const actionCreator = (selected: boolean) => ({
+    type: 'ACTION_CREATOR',
+    payload: selected,
+  })
+  const thunkActionCreator = (selected: boolean) => {
+    return (dispatch: Dispatch) => {
+      return dispatch(actionCreator(selected))
+    }
+  }
+
+  const dispatch = useDispatch()
+  dispatch(actionCreator(true))
+  dispatch(thunkActionCreator(true))
+  dispatch(true)
+
+  type ThunkAction<TReturnType> = (dispatch: Dispatch) => TReturnType
+  type ThunkDispatch = <TReturnType>(
+    action: ThunkAction<TReturnType>
+  ) => TReturnType
+  // tslint:disable-next-line:no-unnecessary-callback-wrapper (required for the generic parameter)
+  const useThunkDispatch = () => useDispatch<ThunkDispatch>()
+  const thunkDispatch = useThunkDispatch()
+  const result: ReturnType<typeof actionCreator> = thunkDispatch(
+    thunkActionCreator(true)
+  )
+}
+
+function testUseSelector() {
+  interface State {
+    counter: number
+    active: string
+  }
+
+  const selector = (state: State) => {
+    return {
+      counter: state.counter,
+      active: state.active,
+    }
+  }
+  const { counter, active } = useSelector(selector)
+  counter === 1
+  // @ts-expect-error
+  counter === '321'
+  active === 'hi'
+  // @ts-expect-error
+  active === {}
+
+  // @ts-expect-error
+  const { extraneous } = useSelector(selector)
+  useSelector(selector)
+
+  // @ts-expect-error
+  useSelector(selector, 'a')
+  useSelector(selector, (l, r) => l === r)
+  useSelector(selector, (l, r) => {
+    // $ExpectType { counter: number; active: string; }
+    l
+    return l === r
+  })
+
+  const correctlyInferred: State = useSelector(selector, shallowEqual)
+  // @ts-expect-error
+  const inferredTypeIsNotString: string = useSelector(selector, shallowEqual)
+
+  const compare = (_l: number, _r: number) => true
+  useSelector(() => 1, compare)
+  const compare2 = (_l: number, _r: string) => true
+
+  // @ts-expect-error
+  useSelector(() => 1, compare2)
+
+  interface RootState {
+    property: string
+  }
+
+  const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector
+
+  // $ExpectType string
+  const r = useTypedSelector((state) => {
+    // $ExpectType RootState
+    state
+    return state.property
+  })
+}
+
+function testUseStore() {
+  interface TypedState {
+    counter: number
+    active: boolean
+  }
+  interface TypedAction {
+    type: 'SET_STATE'
+  }
+
+  const untypedStore = useStore()
+  const state = untypedStore.getState()
+  state.things.stuff.anything // any by default
+
+  const typedStore = useStore<TypedState, TypedAction>()
+  const typedState = typedStore.getState()
+  typedState.counter
+  // @ts-expect-error
+  typedState.things.stuff
+}
+
+// These should match the types of the hooks.
+function testCreateHookFunctions() {
+  interface RootState {
+    property: string
+  }
+  interface RootAction {
+    type: 'TEST_ACTION'
+  }
+
+  const Context = React.createContext<
+    ReactReduxContextValue<RootState, RootAction>
+  >(null as any)
+
+  // No context tests
+  // $ExpectType () => Dispatch<AnyAction>
+  createDispatchHook()
+  // $ExpectType <Selected extends unknown>(selector: (state: any) => Selected, equalityFn?: ((previous: Selected, next: Selected) => boolean) | undefined) => Selected
+  createSelectorHook()
+  // $ExpectType () => Store<any, AnyAction>
+  createStoreHook()
+
+  // With context tests
+  // $ExpectType () => Dispatch<RootAction>
+  createDispatchHook(Context)
+  // $ExpectType <Selected extends unknown>(selector: (state: RootState) => Selected, equalityFn?: ((previous: Selected, next: Selected) => boolean) | undefined) => Selected
+  createSelectorHook(Context)
+  // $ExpectType () => Store<RootState, RootAction>
+  createStoreHook(Context)
+}

--- a/test/typetests/tsconfig.json
+++ b/test/typetests/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../tsconfig.test.json"
+  "extends": "../tsconfig.test.json",
+  "compilerOptions": {
+  },
+  "include": ["./*.ts*"],
+  "exclude": []
 }


### PR DESCRIPTION
This PR:

- Updates the typetest run setup to actually work correctly (not sure this was actually catching errors previously)
- Ports over the remaining content from the v7 typetests in DefinitelyTyped
- Splits those typetests into a few different files just for separation
- Fills in several missing types in the v8 implementation (such as `useStore` not having generics)
- Switches `connect` from being defined with separate function overloads to reusing the same `Connect` overloaded interface from v7, to resolve a "no overload matches" error and allow use of `Connect<SomeState>`
- Fixes several issues with the ported typetests
- Removes some dead types (like that weird `ResolveArrayThunks` type that appears to be _completely_ unused after a full Github search)

Fixes #1854 

I'm still kinda confused how I ended up only porting about 1/3 of the DT v7 typetests during the earlier conversion work.  Maybe I just saw the middle segment of tests as the easiest thing to grab?  Can't remember.

Here's the v7 typetests file for comparison:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5f1a94967148173f78ff00792c29ef5f2a1a3edb/types/react-redux/react-redux-tests.tsx