### PR TITLE
Make VScode to always use the local TS version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
This is something that is very annoying with VScode - by default, it's always using the TS version that is bundled in it, instead of using what the project is actually using. This can lead to different things being observed in the IDE and when running `tsc` or similar so I highly recommend adding this file to your project.