### PR TITLE
Cleanup more code after `pure` removal

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -528,7 +528,6 @@ function connect<
     const displayName = `Connect(${wrappedComponentName})`
 
     const selectorFactoryOptions: SelectorFactoryOptions<any, any, any, any> = {
-      pure,
       shouldHandleStateChanges,
       displayName,
       wrappedComponentName,
@@ -542,11 +541,6 @@ function connect<
       areOwnPropsEqual,
       areMergedPropsEqual,
     }
-
-    // If we aren't running in "pure" mode, we don't want to memoize values.
-    // To avoid conditionally calling hooks, we fall back to a tiny wrapper
-    // that just executes the given callback immediately.
-    const usePureOnlyMemo = pure ? useMemo : (callback: () => any) => callback()
 
     function ConnectFunction<TOwnProps>(
       props: InternalConnectProps & TOwnProps
@@ -667,7 +661,7 @@ function connect<
         }
       }, [])
 
-      const actualChildPropsSelector = usePureOnlyMemo(() => {
+      const actualChildPropsSelector = useMemo(() => {
         const selector = () => {
           // Tricky logic here:
           // - This render may have been triggered by a Redux store update that produced new child props
@@ -790,7 +784,6 @@ function connect<
       return renderedChild
     }
 
-    // If we're in "pure" mode, ensure our wrapper component only re-renders when incoming props have changed.
     const _Connect = React.memo(ConnectFunction)
 
     type ConnectedWrapperComponent = typeof _Connect & {


### PR DESCRIPTION
Those code lines were redundant since this option is not supported anymore:
https://github.com/reduxjs/react-redux/blob/93d5ee5e1fd94b76040645336d483e9f9574de20/src/components/connect.tsx#L477-L483