### PR TITLE
Add option to display the last update time on docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,6 +18,7 @@ const siteConfig = {
           path: '../docs',
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateTime: true,
           editUrl: 'https://github.com/reduxjs/react-redux/edit/master/website',
           include: [
             '{api,introduction,using-react-redux,tutorials}/*.{md,mdx}',


### PR DESCRIPTION
There's no way to tell if we are reading a new version of the docs besides reading it entirely (or looking at the Git history).

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148601214-a369c88c-bc0f-4730-9170-ecb8f20f9d8d.png)