### PR TITLE
test: Adjust type tests to be compatible with React 18 typings

### DIFF
--- a/test/typetests/react-redux-types.typetest.tsx
+++ b/test/typetests/react-redux-types.typetest.tsx
@@ -99,7 +99,12 @@ class App extends Component<any, any> {
 
 const targetEl = document.getElementById('root')
 
-ReactDOM.render(<Provider store={store}>{() => <App />}</Provider>, targetEl)
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  targetEl
+)
 
 declare var store: Store<TodoState>
 class MyRootComponent extends Component<any, any> {}
@@ -125,7 +130,9 @@ declare var todoActionCreators: { [type: string]: (...args: any[]) => any }
 declare var counterActionCreators: { [type: string]: (...args: any[]) => any }
 
 ReactDOM.render(
-  <Provider store={store}>{() => <MyRootComponent />}</Provider>,
+  <Provider store={store}>
+    <MyRootComponent />
+  </Provider>,
   document.body
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,18 +2616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 17.0.19
-  resolution: "@types/react@npm:17.0.19"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: 369578687b39d66fafcb2e41b9e12a0aa0dda8db5661b68d4c9bd7679d3da96515c69905b1a882f2da01988104dca30d400811e1488ed146ac98d246e8e67695
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^17.0.35":
+"@types/react@npm:*, @types/react@npm:^17.0.35":
   version: 17.0.35
   resolution: "@types/react@npm:17.0.35"
   dependencies:


### PR DESCRIPTION
Ports https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58289 to current typings as requested in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58289#pullrequestreview-855908766

Also deduped `@types/react` packages. Duplicate types packages is usually not supported. It also helped patching local typings.

`yarn type-tests` passes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210 with these changes.