### PR TITLE
Switch back to Subscription in useSelector to fix unsubscribe perf

### DIFF
--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,4 +1,4 @@
-import { useContext, useDebugValue } from 'react'
+import { useContext, useDebugValue, useCallback } from 'react'
 
 import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
 import { ReactReduxContext } from '../components/Context'
@@ -48,12 +48,11 @@ export function createSelectorHook(
       }
     }
 
-    const { store, getServerState } = useReduxContext()!
+    const { store, subscription, getServerState } = useReduxContext()!
 
     const selectedState = useSyncExternalStoreWithSelector(
-      store.subscribe,
+      subscription.addNestedSub,
       store.getState,
-      // TODO Need a server-side snapshot here
       getServerState || store.getState,
       selector,
       equalityFn


### PR DESCRIPTION
The Subscription impl originally used an array of listeners just
like the actual Redux store, but in #1523 we changed it to be a
linked list to fix perf issues. The use of `indexOf+splice` caused
a quadratic cost to unmounting many components.

In v8, I originally dropped use of `Subscription` to potentially
save on bundle size. However, `Provider` still uses `Subscription`,
so that will always be in the bundle.

For this issue, a user pointed out that directly subscribing to the
store brought back the original quadratic unsubscription behavior,
which I've confirmed locally.

Swapping `store.subscribe` for `subscription.addNestedSub` fixes
that issue.

I've added a unit test that mounts and unmounts a massive tree and
measures the elapsed time. There's a distinct difference between
the "correct" and quadratic behavior. Weirdly, there's also a big
diff in "correct" time between React 18, and 17 + the "compat" entry
point, and I have no idea why.  It's not as bad as the quadratic
time, but it's still pretty expensive.

I've written the test to set an acceptable max unmount time based on
which React version we're running against, with some buffer added.

Fixes #1869 .