### PR TITLE
Remove unused useCallback import

### DIFF
--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,4 +1,4 @@
-import { useContext, useDebugValue, useCallback } from 'react'
+import { useContext, useDebugValue } from 'react'
 
 import { useReduxContext as useDefaultReduxContext } from './useReduxContext'
 import { ReactReduxContext } from '../components/Context'


### PR DESCRIPTION
`useCallback` import was added to `src/hooks/useSelector.ts` in https://github.com/reduxjs/react-redux/commit/43d1cc61c0ed257fb8d6ddcb6691020b64f0210b without actually being used.