### PR TITLE
fix(deps): add optional peer deps into `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "@types/react": "^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-native": "^0.64.1"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8931,7 +8931,10 @@ __metadata:
     typescript: ^4.3.4
     use-sync-external-store: ^1.0.0
   peerDependencies:
+    "@types/react": ^18.0.0
     react: ^18.0.0
+    react-dom: ^18.0.0
+    react-native: ^0.64.1
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
In the [NPM docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta), optional peer deps should be specified in `peerDependencies` because this is where the versioning info comes from.  This is the example from the NPM docs:

```
{
  "name": "tea-latte",
  "version": "1.3.5",
  "peerDependencies": {
    "tea": "2.x",
    "soy-milk": "1.2"
  },
  "peerDependenciesMeta": {
    "soy-milk": {
      "optional": true
    }
  }
}
```

One thing I wasn't sure about was the react native compatibility, so I placed the version that's currently in devDeps as a placeholder.  I'll fix this once I get confirmation.