### PR TITLE
Update peer deps for v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "@types/react": "^18.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "react-native": "^0.64.1"
+    "@types/react": "^16.8 || ^17.0 || ^18.0",
+    "react": "^16.8 || ^17.0 || ^18.0",
+    "react-dom": "^16.8 || ^17.0 || ^18.0",
+    "react-native": ">=0.59",
+    "redux": "^4"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -53,6 +54,9 @@
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "redux": {
       "optional": true
     }
   },

--- a/test/integration/ssr.spec.tsx
+++ b/test/integration/ssr.spec.tsx
@@ -126,7 +126,7 @@ describe('New v8 serverState behavior', () => {
     jest.clearAllMocks()
   })
 
-  it.only('Handles hydration correctly', async () => {
+  it('Handles hydration correctly', async () => {
     const ssrStore = createStore(dataSlice.reducer)
 
     // Simulating loading all data before rendering the app

--- a/yarn.lock
+++ b/yarn.lock
@@ -8931,16 +8931,19 @@ __metadata:
     typescript: ^4.3.4
     use-sync-external-store: ^1.0.0
   peerDependencies:
-    "@types/react": ^18.0.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
-    react-native: ^0.64.1
+    "@types/react": ^16.8 || ^17.0 || ^18.0
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+    react-native: ">=0.59"
+    redux: ^4
   peerDependenciesMeta:
     "@types/react":
       optional: true
     react-dom:
       optional: true
     react-native:
+      optional: true
+    redux:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR:

- Widens the v8 peer deps to accept React ^16.8, including RN (0.59)
- Adds `redux` as an optional peer dep for the types