### PR TITLE
Add optional peer dependency on @types/react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8 || ^17.0 || ^18.0",
+    "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
     "react": "^16.8 || ^17.0 || ^18.0",
     "react-dom": "^16.8 || ^17.0 || ^18.0",
     "react-native": ">=0.59",
@@ -48,6 +49,9 @@
   },
   "peerDependenciesMeta": {
     "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
       "optional": true
     },
     "react-dom": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8932,12 +8932,15 @@ __metadata:
     use-sync-external-store: ^1.0.0
   peerDependencies:
     "@types/react": ^16.8 || ^17.0 || ^18.0
+    "@types/react-dom": ^16.8 || ^17.0 || ^18.0
     react: ^16.8 || ^17.0 || ^18.0
     react-dom: ^16.8 || ^17.0 || ^18.0
     react-native: ">=0.59"
     redux: ^4
   peerDependenciesMeta:
     "@types/react":
+      optional: true
+    "@types/react-dom":
       optional: true
     react-dom:
       optional: true


### PR DESCRIPTION
The type declarations reference `react-dom` so there should be an optional peer dependency on `@types/react-dom`.

Without this change there's a TS error (when using strict package managers and skipLibCheck is set to false):
```
ERROR in ../../.yarn/__virtual__/react-redux-virtual-4a1b050619/0/cache/react-redux-npm-8.0.0-e71f82730a-466c36e490.zip/node_modules/react-redux/es/utils/reactBatchedUpdates.d.ts 1:41-52
TS7016: Could not find a declaration file for module 'react-dom'. '/home/runner/work/ParagonCore/ParagonCore/.yarn/__virtual__/react-dom-virtual-fe5af9a498/0/cache/react-dom-npm-17.0.2-f551215af1-1c1eaa3bca.zip/node_modules/react-dom/index.js' implicitly has an 'any' type.
  If the 'react-dom' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-dom'
  > 1 | export { unstable_batchedUpdates } from 'react-dom';
      |                                         ^^^^^^^^^^^
    2 |
```