### PR TITLE
fix(ts): incorrect import of `Subscription` causes `noImplicitAny` error

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -27,7 +27,7 @@ import { useSelector, createSelectorHook } from './hooks/useSelector'
 import { useStore, createStoreHook } from './hooks/useStore'
 
 import shallowEqual from './utils/shallowEqual'
-import type { Subscription } from '../src/utils/Subscription'
+import type { Subscription } from './utils/Subscription'
 
 export * from './types'
 export type {


### PR DESCRIPTION
Closes #1909 , see [this comment](https://github.com/reduxjs/react-redux/issues/1909#issuecomment-1102907378) for context.