### PR TITLE
Simplify the useAppDispatch definition

### DIFF
--- a/docs/tutorials/typescript.md
+++ b/docs/tutorials/typescript.md
@@ -86,7 +86,7 @@ import type { RootState, AppDispatch } from './store'
 
 // highlight-start
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppDispatch: () => AppDispatch = useDispatch
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 // highlight-end
 ```

--- a/docs/using-react-redux/usage-with-typescript.md
+++ b/docs/using-react-redux/usage-with-typescript.md
@@ -69,7 +69,7 @@ import type { RootState, AppDispatch } from './store'
 
 // highlight-start
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppDispatch: () => AppDispatch = useDispatch
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 // highlight-end
 ```


### PR DESCRIPTION
This PR is related to issue #1925 and shortens the definition of `useAppDispatch` in the documentation.