### PR TITLE
Remove redundant `isMounted` ref from `connect`

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -103,7 +103,6 @@ function subscribeUpdates(
   lastWrapperProps: React.MutableRefObject<unknown>,
   lastChildProps: React.MutableRefObject<unknown>,
   renderIsScheduled: React.MutableRefObject<boolean>,
-  isMounted: React.MutableRefObject<boolean>,
   childPropsFromStoreUpdate: React.MutableRefObject<unknown>,
   notifyNestedSubs: () => void,
   // forceComponentUpdateDispatch: React.Dispatch<any>,
@@ -118,7 +117,7 @@ function subscribeUpdates(
 
   // We'll run this callback every time a store subscription update propagates to this component
   const checkForUpdates = () => {
-    if (didUnsubscribe || !isMounted.current) {
+    if (didUnsubscribe) {
       // Don't run stale listeners.
       // Redux doesn't guarantee unsubscriptions happen until next dispatch.
       return
@@ -622,17 +621,8 @@ function connect<
       const lastWrapperProps = useRef(wrapperProps)
       const childPropsFromStoreUpdate = useRef<unknown>()
       const renderIsScheduled = useRef(false)
-      const isProcessingDispatch = useRef(false)
-      const isMounted = useRef(false)
 
       const latestSubscriptionCallbackError = useRef<Error>()
-
-      useIsomorphicLayoutEffect(() => {
-        isMounted.current = true
-        return () => {
-          isMounted.current = false
-        }
-      }, [])
 
       const actualChildPropsSelector = useMemo(() => {
         const selector = () => {
@@ -677,7 +667,6 @@ function connect<
             lastWrapperProps,
             lastChildProps,
             renderIsScheduled,
-            isMounted,
             childPropsFromStoreUpdate,
             notifyNestedSubs,
             reactListener


### PR DESCRIPTION
*Most likely* this should fix https://github.com/reduxjs/react-redux/issues/1940 . It would be cool if @markerikson or @bvaughn could test this out using the parent of this commit in Replay: https://github.com/replayio/devtools/commit/477dd472eebf5210213500e798f6c94a7fad8c86