### PR TITLE
selectorFactory: pass ownProps to areStatesEqual

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -130,7 +130,7 @@ const mapStateToProps = (...args) => {
 
 When `options.pure` is true, `connect` performs several equality checks that are used to avoid unnecessary calls to `mapStateToProps`, `mapDispatchToProps`, `mergeProps`, and ultimately to `render`. These include `areStatesEqual`, `areOwnPropsEqual`, `areStatePropsEqual`, and `areMergedPropsEqual`. While the defaults are probably appropriate 99% of the time, you may wish to override them with custom implementations for performance or other reasons. Here are several examples:
 
-* You may wish to override `areStatesEqual` if your `mapStateToProps` function is computationally expensive and is also only concerned with a small slice of your state. For example: `areStatesEqual: (next, prev) => prev.entities.todos === next.entities.todos`; this would effectively ignore state changes for everything but that slice of state.
+* You may wish to override `areStatesEqual` if your `mapStateToProps` function is computationally expensive and is also only concerned with a small slice of your state. For example: `areStatesEqual: (next, prev) => prev.entities.todos === next.entities.todos`; this would effectively ignore state changes for everything but that slice of state. Additionally, `areStatesEqual` provides `nextOwnProps` and `prevOwnProps` to allow for more effective scoping of your state which your connected component is interested in, if needed.
 
 * You may wish to override `areStatesEqual` to always return false (`areStatesEqual: () => false`) if you have impure reducers that mutate your store state. (This would likely impact the other equality checks as well, depending on your `mapStateToProps` function.)
 

--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -73,7 +73,7 @@ export function pureFinalPropsSelectorFactory(
 
   function handleSubsequentCalls(nextState, nextOwnProps) {
     const propsChanged = !areOwnPropsEqual(nextOwnProps, ownProps)
-    const stateChanged = !areStatesEqual(nextState, state)
+    const stateChanged = !areStatesEqual(nextState, state, nextOwnProps, ownProps)
     state = nextState
     ownProps = nextOwnProps
 


### PR DESCRIPTION
This PR adds the ability for consumers to have access to `ownProps` inside of `areStatesEqual`.

Currently there is no way to 

See: https://github.com/reduxjs/react-redux/issues/781