### PR TITLE
connect: pass ownProps to areStatesEqual

### DIFF
--- a/docs/api/connect.md
+++ b/docs/api/connect.md
@@ -236,7 +236,7 @@ When `options.pure` is true, `connect` performs several equality checks that are
 
 We provide a few examples in the following sections.
 
-#### `areStatesEqual: (next: Object, prev: Object) => boolean`
+#### `areStatesEqual: (next: Object, prev: Object, nextOwnProps: Object, prevOwnProps: Object) => boolean`
 
 - default value: `strictEqual: (next, prev) => prev === next`
 
@@ -249,7 +249,7 @@ const areStatesEqual = (next, prev) =>
   prev.entities.todos === next.entities.todos
 ```
 
-You may wish to override `areStatesEqual` if your `mapStateToProps` function is computationally expensive and is also only concerned with a small slice of your state. The example above will effectively ignore state changes for everything but that slice of state.
+You may wish to override `areStatesEqual` if your `mapStateToProps` function is computationally expensive and is also only concerned with a small slice of your state. The example above will effectively ignore state changes for everything but that slice of state. Additionally, `areStatesEqual` provides `nextOwnProps` and `prevOwnProps` to allow for more effective scoping of your state which your connected component is interested in, if needed.
 
 _Example 2_
 

--- a/src/connect/selectorFactory.js
+++ b/src/connect/selectorFactory.js
@@ -73,7 +73,7 @@ export function pureFinalPropsSelectorFactory(
 
   function handleSubsequentCalls(nextState, nextOwnProps) {
     const propsChanged = !areOwnPropsEqual(nextOwnProps, ownProps)
-    const stateChanged = !areStatesEqual(nextState, state)
+    const stateChanged = !areStatesEqual(nextState, state, nextOwnProps, ownProps)
     state = nextState
     ownProps = nextOwnProps
 


### PR DESCRIPTION
This PR adds the ability for consumers to have access to ownProps inside of areStatesEqual.

Currently there is no way to

See: https://github.com/reduxjs/react-redux/issues/781