### PR TITLE
Omit built-in context prop if user component props include context

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable valid-jsdoc, @typescript-eslint/no-unused-vars */
 import hoistStatics from 'hoist-non-react-statics'
-import React, { useContext, useMemo, useRef } from 'react'
+import React, { ComponentType, useContext, useMemo, useRef } from 'react'
 import { isValidElementType, isContextConsumer } from 'react-is'
 
 import type { Store } from 'redux'
 
 import type {
-  AdvancedComponentDecorator,
   ConnectedComponent,
   InferableComponentEnhancer,
   InferableComponentEnhancerWithProps,
   ResolveThunks,
   DispatchProp,
+  ConnectPropsMaybeWithoutContext,
 } from '../types'
 
 import defaultSelectorFactory, {
@@ -465,18 +465,18 @@ function connect<
 
   const Context = context
 
-  type WrappedComponentProps = TOwnProps & ConnectProps
-
   const initMapStateToProps = mapStateToPropsFactory(mapStateToProps)
   const initMapDispatchToProps = mapDispatchToPropsFactory(mapDispatchToProps)
   const initMergeProps = mergePropsFactory(mergeProps)
 
   const shouldHandleStateChanges = Boolean(mapStateToProps)
 
-  const wrapWithConnect: AdvancedComponentDecorator<
-    TOwnProps,
-    WrappedComponentProps
-  > = (WrappedComponent) => {
+  const wrapWithConnect = <TProps,>(
+    WrappedComponent: ComponentType<TProps>
+  ) => {
+    type WrappedComponentProps = TProps &
+      ConnectPropsMaybeWithoutContext<TProps>
+
     if (
       process.env.NODE_ENV !== 'production' &&
       !isValidElementType(WrappedComponent)

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,10 +25,6 @@ export interface DispatchProp<A extends Action = AnyAction> {
   dispatch: Dispatch<A>
 }
 
-export type AdvancedComponentDecorator<TProps, TOwnProps> = (
-  component: ComponentType<TProps>
-) => ComponentType<TOwnProps>
-
 /**
  * A property P will be present if:
  * - it is present in DecorationTargetProps
@@ -92,10 +88,17 @@ export type ConnectedComponent<
     WrappedComponent: C
   }
 
+export type ConnectPropsMaybeWithoutContext<TActualOwnProps> =
+  TActualOwnProps extends { context: any }
+    ? Omit<ConnectProps, 'context'>
+    : ConnectProps
+
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
-// Uses distributive omit to preserve discriminated unions part of original prop type
+// Uses distributive omit to preserve discriminated unions part of original prop type.
+// Note> Most of the time TNeedsProps is empty, because the overloads in `Connect`
+// just pass in `{}`.  The real props we need come from the component.
 export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> = <
   C extends ComponentType<Matching<TInjectedProps, GetProps<C>>>
 >(
@@ -107,7 +110,7 @@ export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> = <
     keyof Shared<TInjectedProps, GetLibraryManagedProps<C>>
   > &
     TNeedsProps &
-    ConnectProps
+    ConnectPropsMaybeWithoutContext<TNeedsProps & GetProps<C>>
 >
 
 // Injects props and removes them from the prop requirements.

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,9 @@ export type ConnectPropsMaybeWithoutContext<TActualOwnProps> =
     ? Omit<ConnectProps, 'context'>
     : ConnectProps
 
+type Identity<T> = T
+export type Mapped<T> = Identity<{ [k in keyof T]: T[k] }>
+
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
@@ -105,12 +108,14 @@ export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> = <
   component: C
 ) => ConnectedComponent<
   C,
-  DistributiveOmit<
-    GetLibraryManagedProps<C>,
-    keyof Shared<TInjectedProps, GetLibraryManagedProps<C>>
-  > &
-    TNeedsProps &
-    ConnectPropsMaybeWithoutContext<TNeedsProps & GetProps<C>>
+  Mapped<
+    DistributiveOmit<
+      GetLibraryManagedProps<C>,
+      keyof Shared<TInjectedProps, GetLibraryManagedProps<C>>
+    > &
+      TNeedsProps &
+      ConnectPropsMaybeWithoutContext<TNeedsProps & GetProps<C>>
+  >
 >
 
 // Injects props and removes them from the prop requirements.

--- a/test/typetests/connect-options-and-issues.tsx
+++ b/test/typetests/connect-options-and-issues.tsx
@@ -465,7 +465,7 @@ function TestOptionalPropsMergedCorrectly() {
     }
   }
 
-  connect(mapStateToProps, mapDispatchToProps)(Component)
+  const Connected = connect(mapStateToProps, mapDispatchToProps)(Component)
 }
 
 function TestMoreGeneralDecorationProps() {


### PR DESCRIPTION
This PR:

- Reworks the type inference for `connect` so that if the user's component expects `props.context` already, we use that type instead of the possible alternate `context: ReactReduxContext` type
- Uses a `Mapped` type to simplify the hover display types for connected components.

Connected components allow users to pass in a `ReactReduxContext` instance as a prop named `context`. We also do internal checks to see if that really _is_ a context instance, in case the user passed a real value as `props.context`.

However, the TS types did not reflect this - `props.context` was always a `ReactReduxContext` type, and if users did have a component that accepted a prop named `context`, this would cause a type clash.

In this case, the types didn't reflect the reality of runtime behavior.

By extracting "the props of the component" and omitting the built-in `context` field type if appropriate, this now works.


Fixes #1957 .


Additionally: due to the ridiculous types-level shenanigans inside of `connect`, the hover display of connected components is incredibly obtuse and hard to read.  

Over the last year I've experimented with several different util types that "expand/flatten" a TS typedef to make the actual fields more readable (and by "experimented" I mean "I stole them from other repos and pasted them in to see what would happen").  One of the simpler ones is a `Mapped` type:

```ts
type Identity<T> = T
export type Mapped<T> = Identity<{ [k in keyof T]: T[k] }>
```

(I don't pretend to understand all the magic there, but it works!)

By inserting that at the right spot in the connected inference sequence, we get a much better hover display for connected components.

Some examples from our type tests:

```ts
// Before:
const ConnectedButton: ConnectedComponent<(props: IButtonProps) => JSX.Element, Omit<IButtonOwnProps & {
    name: string;
} & DispatchProp<AnyAction>, "dispatch" | "name"> & {
    ...;
}>

// After
const ConnectedButton: ConnectedComponent<(props: IButtonProps) => JSX.Element, {
    label: string;
    context: 'LIST' | 'CARD';
    store?: Store<any, AnyAction> | undefined;
}>
```

```ts
// Before:
const Test: ConnectedComponent<typeof TestComponent, Omit<React.ClassAttributes<TestComponent> & OwnProps & StateProps & DispatchProps, "bar" | "onClick"> & {
    ...;
}>

// After
const Test: ConnectedComponent<typeof TestComponent, {
    foo: string;
    ref?: React.LegacyRef<TestComponent> | undefined;
    key?: React.Key | null | undefined;
    context?: React.Context<ReactReduxContextValue<any, AnyAction>> | undefined;
    store?: Store<...> | undefined;
}>
```

Most users aren't going to care about the `ref/key/context/store` part... but it _is_ much easier to read _and_ more accurate.  So we're throwing that in here as a bonus.