### PR TITLE
`Provider`: pass state (`S`) generic through to `ProviderProps`

### DIFF
--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -4,7 +4,7 @@ import { createSubscription } from '../utils/Subscription'
 import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
 import { Action, AnyAction, Store } from 'redux'
 
-export interface ProviderProps<A extends Action = AnyAction, S = any> {
+export interface ProviderProps<A extends Action = AnyAction, S = unknown> {
   /**
    * The single Redux store in your application.
    */
@@ -24,7 +24,7 @@ export interface ProviderProps<A extends Action = AnyAction, S = any> {
   children: ReactNode
 }
 
-function Provider<A extends Action = AnyAction, S = any>({
+function Provider<A extends Action = AnyAction, S = unknown>({
   store,
   context,
   children,

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -24,12 +24,12 @@ export interface ProviderProps<A extends Action = AnyAction, S = any> {
   children: ReactNode
 }
 
-function Provider<A extends Action = AnyAction>({
+function Provider<A extends Action = AnyAction, S = any>({
   store,
   context,
   children,
   serverState,
-}: ProviderProps<A>) {
+}: ProviderProps<A, S>) {
   const contextValue = useMemo(() => {
     const subscription = createSubscription(store)
     return {

--- a/test/typetests/provider.tsx
+++ b/test/typetests/provider.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import React from 'react'
+import { Provider } from '../../src'
+import { Store } from 'redux'
+
+declare const store: Store<{ foo: string }>
+
+function App() {
+  return (
+    <Provider
+      store={store}
+      // @ts-expect-error
+      serverState={'oops'}
+    >
+      foo
+    </Provider>
+  )
+}


### PR DESCRIPTION
This is necessary to catch mistakes such as this, where the type of `serverState` does not match the type of the state in the provided `store`. (I just shipped this bug to unsplash.com!)

```tsx
import { Provider } from 'react-redux';
import { Store } from 'redux';

declare const store: Store<{ foo: string }>;
<Provider store={store} serverState={"oops"}>foo</Provider>
```