### PR TITLE
fix(types): infer props from class components in React 16

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 import {
-  ClassAttributes,
-  ComponentClass,
+  JSXElementConstructor,
   ComponentType,
   FunctionComponent,
+  ComponentClass,
+  ClassAttributes,
+  ComponentPropsWithRef,
 } from 'react'
 
 import { Action, AnyAction, Dispatch } from 'redux'
@@ -71,6 +73,8 @@ export type GetProps<C> = C extends ComponentType<infer P>
   ? C extends ComponentClass<P>
     ? ClassAttributes<InstanceType<C>> & P
     : P
+  : C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+  ? ComponentPropsWithRef<C>
   : never
 
 // Applies LibraryManagedAttributes (proper handling of defaultProps
@@ -105,7 +109,7 @@ export type Mapped<T> = Identity<{ [k in keyof T]: T[k] }>
 // Note> Most of the time TNeedsProps is empty, because the overloads in `Connect`
 // just pass in `{}`.  The real props we need come from the component.
 export type InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> = <
-  C extends ComponentType<Matching<TInjectedProps, GetProps<C>>>
+  C extends JSXElementConstructor<Matching<TInjectedProps, GetProps<C>>>
 >(
   component: C
 ) => ConnectedComponent<


### PR DESCRIPTION
Addresses #1644 which adds support for inferring props from class components (specifically PureComponents) in React v16. In React v16, not all components extend "ComponentType".

On the other hand, JSXElementConstructor handles class components and function components. For getting props, fallback to React's built-in props utility. I initially tried replacing GetProps with React.ComponentProps, but ran into some issues with refs. This is likely a "safer" change that won't be breaking in any way.