### PR TITLE
lazily create Context for RSC compat

### DIFF
--- a/src/components/Context.ts
+++ b/src/components/Context.ts
@@ -26,7 +26,7 @@ function getContext() {
 
 export const ReactReduxContext = /*#__PURE__*/ new Proxy(
   {} as Context<ReactReduxContextValue>,
-  new Proxy<ProxyHandler<Context<ReactReduxContextValue>>>(
+  /*#__PURE__*/ new Proxy<ProxyHandler<Context<ReactReduxContextValue>>>(
     {},
     {
       get(_, handler) {

--- a/src/components/Context.ts
+++ b/src/components/Context.ts
@@ -1,4 +1,5 @@
-import { Context, createContext } from 'react'
+import { createContext } from 'react'
+import type { Context } from 'react'
 import type { Action, AnyAction, Store } from 'redux'
 import type { Subscription } from '../utils/Subscription'
 import { StabilityCheck } from '../hooks/useSelector'


### PR DESCRIPTION
This PR introduces a Proxy around a lazily initialized `ReactReduxContext` object to prevent the dreaded "`React.createContext` is not a function" error when the `ReactReduxContext` is referenced, but not actually used, in a React Server Component context (for example by importing, but not calling, one of the hooks - e.g. when using `createApi` from RTK Query).

I'm not sure where on the line between "mad genius" and "evil genius" this is right now...