### PR TITLE
fix: fix typescript error on non exported type

### DIFF
--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -17,7 +17,7 @@ export interface UseSelectorOptions<Selected = unknown> {
   noopCheck?: CheckFrequency
 }
 
-interface UseSelector {
+export interface UseSelector {
   <TState = unknown, Selected = unknown>(
     selector: (state: TState) => Selected,
     equalityFn?: EqualityFn<Selected>


### PR DESCRIPTION
After upgrading to `react-redux` v8.1.0 I noticed a new Typescript error appearing at build time in my project. 
The project uses a custom context for Redux's store and creates custom `useStore`, `useDispatch` and `useSelector` hooks via the provided functions.

The error says:

```
Exported variable 'useSelector' has or is using name 'UseSelector' from external module [path to local react-redux dep] but cannot be named
```

The simple fix here is to export the `UseSelector` type from the type definition (I've tested it locally).