### PR TITLE
fix: Update hooks.md to fix custom equality function example 

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -125,7 +125,7 @@ const selectedData = useSelector(selectorReturningObject, {
 import { useSelector } from 'react-redux'
 
 // equality function
-const customEqual = (oldValue, newValue) => oldValue === newValue
+const customEqual = (newValue, oldValue) => newValue === oldValue
 
 // later
 const selectedData = useSelector(selectorReturningObject, customEqual)


### PR DESCRIPTION
Custom equality function documentation mixes up the new and previous value variables in the example code.

See logs in this code sandbox example: https://codesandbox.io/s/redux-useselector-usedispatch-sample-forked-zhfnx5?file=/src/Counter.js

You can also see the screenshot below following the example naming in the documentation. The logged result is after incrementing the count.

<img width="1165" alt="Screen Shot 2023-06-15 at 7 03 46 PM" src="https://github.com/reduxjs/react-redux/assets/17553397/7f33aa94-86d5-49e3-ba22-ac16f86cc0b8">
