### PR TITLE
Change react-native output extension from `.mjs` to `.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "bugs": "https://github.com/reduxjs/react-redux/issues",
   "module": "dist/react-redux.legacy-esm.js",
   "main": "dist/cjs/index.js",
-  "react-native": "./dist/react-redux.react-native.mjs",
+  "react-native": "./dist/react-redux.react-native.js",
   "types": "dist/react-redux.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/react-redux.d.ts",
       "react-server": "./dist/rsc.mjs",
-      "react-native": "./dist/react-redux.react-native.mjs",
+      "react-native": "./dist/react-redux.react-native.js",
       "import": "./dist/react-redux.mjs",
       "default": "./dist/cjs/index.js"
     },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -83,7 +83,7 @@ export default defineConfig((options) => {
         'react-redux.react-native': 'src/react-native.ts',
       },
       format: ['esm'],
-      outExtension: () => ({ js: '.mjs' }),
+      outExtension: () => ({ js: '.js' }),
     },
     // CJS development
     {


### PR DESCRIPTION
As of right now the newest React-Redux release fixed the `react-dom` import issue in react-native, but it broke some Expo apps. If you're using Expo (specifically `create-expo-app`),  you'll get `Unable to resolve "react-redux"`, and that's because Expo by default doesn't pick up `.mjs, .cjs` extensions, the workaround is to add a `metro.config.js` file and add this to it:

```js
const { getDefaultConfig } = require('expo/metro-config');

/** @type {import('expo/metro-config').MetroConfig} */
const config = getDefaultConfig(__dirname);
config.resolver.sourceExts.push('mjs');

module.exports = config;
```

This PR changes the react-native output extension from `.mjs` to `.js` which fixes the issue with both React-Native and Expo-Reacy-Native combination apps.