### PR TITLE
Add Expo and React Native to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         node: ['16.x']
-        example: ['cra4', 'cra5', 'next', 'vite', 'node-standard', 'node-esm']
+        example: ['cra4', 'cra5', 'next', 'vite', 'node-standard', 'node-esm', 'react-native', 'expo']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR:

  - [X] Adds Expo and React Native examples to CI workflow.