### PR TITLE
Move `Equals` constraint into an intersection type.

### DIFF
--- a/test/typeTestHelpers.ts
+++ b/test/typeTestHelpers.ts
@@ -47,7 +47,7 @@ export declare const exactType: <T, U>(
 ) => IfEquals<T, U>
 
 export function expectExactType<T>(t: T) {
-  return <U extends Equals<T, U>>(u: U) => {}
+  return <U extends T>(u: U & Equals<T, U>) => {}
 }
 
 type EnsureUnknown<T> = IsUnknown<T, any, never>


### PR DESCRIPTION
In https://github.com/microsoft/TypeScript/issues/57117, we noticed that react-redux's build is impacted by a change in in https://github.com/microsoft/TypeScript/issues/56515. What this means is that TypeScript 5.4, you'll get an error in `expectExactType`.

```ts
export function expectExactType<T>(t: T) {
  return <U extends Equals<T, U>>(u: U) => {}
//        ~
// error TS2313: Type parameter 'U' has a circular constraint.
}
```

The solution I would suggest for now is to just make `U` extend `T` and move the constraint to an intersection wherever you use `U`.

```diff
-  return <U extends Equals<T, U>>(u: U) => {}
+  return <U extends T>(u: U & Equals<T, U>) => {}
```