### PR TITLE
Cache the examples and speed up test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Install Playwright browser if necessary
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
         continue-on-error: true
-        run: yarn playwright install
+        run: yarn playwright install || true
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
             ~/.gradle/wrapper
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
-          key: test-published-artifact-${{ matrix.example }}-${{ hashFiles('**/*.gradle*') }}
+          key: test-published-artifact-${{ matrix.example }}-${{ hashFiles(format('./redux-toolkit/examples/publish-ci/{0}/android/.gradle', matrix.example)) }}
 
       - name: Clone RTK repo
         run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,8 @@ jobs:
 
       - name: Build example
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: yarn build
 
       - name: Run test step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
           cache: 'yarn'
 
       - name: Cache React Native build artifacts
-        if: contains(['react-native', 'expo'], matrix.example)
+        if: contains(fromJson('["react-native", "expo"]'), matrix.example)
         uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,16 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
+      - name: Cache React Native build artifacts
+        if: matrix.example == 'react-native'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
+          key: test-published-artifact-${{ matrix.example }}-${{ hashFiles('**/*.gradle*') }}
+
       - name: Clone RTK repo
         run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,15 +138,12 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-            ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
-            ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
           key: test-published-artifact-${{ matrix.example }}-gradle
 
       - name: Cache example deps
         uses: actions/cache@v4
         with:
-          path: |
-            ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/node_modules
+          path: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/node_modules
           key: test-published-artifact-${{ matrix.example }}-node_modules
 
       - name: Check folder contents

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,15 +131,6 @@ jobs:
       - name: Clone RTK repo
         run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit
 
-      - name: Cache React Native build artifacts
-        if: contains(fromJson('["react-native", "expo"]'), matrix.example)
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: test-published-artifact-${{ matrix.example }}-gradle
-
       - name: Cache example deps
         uses: actions/cache@v4
         with:
@@ -183,6 +174,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Build example
+        if: '!contains(fromJson(''["react-native", "expo"]''), matrix.example)'
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
         env:
           NODE_OPTIONS: --openssl-legacy-provider

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,7 @@ jobs:
             ~/.gradle/wrapper
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
+            ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/node_modules
           key: test-published-artifact-${{ matrix.example }}
 
       - name: Check folder contents

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,13 +129,14 @@ jobs:
           cache: 'yarn'
 
       - name: Cache React Native build artifacts
-        if: matrix.example == 'react-native'
+        if: contains(['react-native', 'expo'], matrix.example)
         uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
+            ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
           key: test-published-artifact-${{ matrix.example }}-${{ hashFiles('**/*.gradle*') }}
 
       - name: Clone RTK repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,9 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
 
+      - name: Clone RTK repo
+        run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit
+
       - name: Cache React Native build artifacts
         if: contains(fromJson('["react-native", "expo"]'), matrix.example)
         uses: actions/cache@v4
@@ -138,9 +141,6 @@ jobs:
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
           key: test-published-artifact-${{ matrix.example }}
-
-      - name: Clone RTK repo
-        run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit
 
       - name: Check folder contents
         run: ls -l .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,21 +145,9 @@ jobs:
       - name: Check folder contents
         run: ls -l .
 
-        # Some weird install diffs with cloning this repo and installing.
-        # Just kill the lockfiles for React-Redux and RTK and reinstall
-
-      - name: Remove React-Redux lockfile
-        run: rm yarn.lock && rm package.json
-
-      - name: Remove RTK lockfile
-        working-directory: ./redux-toolkit
-        run: rm yarn.lock && rm package.json
-
-      - name: Install deps
+      - name: Install example deps
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
-        env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
-        run: rm yarn.lock && yarn install
+        run: yarn install
 
       - name: Install Playwright browser if necessary
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
@@ -192,8 +180,6 @@ jobs:
 
       - name: Build example
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
-        env:
-          NODE_OPTIONS: --openssl-legacy-provider
         run: yarn build
 
       - name: Run test step

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,15 +166,7 @@ jobs:
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
         run: yarn info react-redux && yarn why react-redux
 
-      - name: Set up JDK 17 for React Native build
-        if: matrix.example == 'react-native'
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17.x'
-          distribution: 'temurin'
-
       - name: Build example
-        if: '!contains(fromJson(''["react-native", "expo"]''), matrix.example)'
         working-directory: ./redux-toolkit/examples/publish-ci/${{ matrix.example }}
         env:
           NODE_OPTIONS: --openssl-legacy-provider

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,8 +140,14 @@ jobs:
             ~/.gradle/wrapper
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
+          key: test-published-artifact-${{ matrix.example }}-gradle
+
+      - name: Cache example deps
+        uses: actions/cache@v4
+        with:
+          path: |
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/node_modules
-          key: test-published-artifact-${{ matrix.example }}
+          key: test-published-artifact-${{ matrix.example }}-node_modules
 
       - name: Check folder contents
         run: ls -l .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
             ~/.gradle/wrapper
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/android/.gradle
             ./redux-toolkit/examples/publish-ci/${{ matrix.example }}/.expo
-          key: test-published-artifact-${{ matrix.example }}-${{ hashFiles(format('./redux-toolkit/examples/publish-ci/{0}/android/.gradle', matrix.example)) }}
+          key: test-published-artifact-${{ matrix.example }}
 
       - name: Clone RTK repo
         run: git clone https://github.com/reduxjs/redux-toolkit.git ./redux-toolkit

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage
 es
 temp/
 react-redux-*/
+redux-toolkit/
 .vscode/
 
 .cache/


### PR DESCRIPTION
Adding the RN examples ballooned our test runs to 10+ minutes, which seems like a lot of overkill. But we were doing zero caching, so we got dinged with a full, from-scatch build on each run. Big ick.

Turns out, we don't really need to build an entire app. What we're testing is if Metro will bundle our build output. So, I'll make an equivalent RTK PR to simplify that build step drastically.

Update: Just made reduxjs/redux-toolkit#4266 to speed things up on that end