### PR TITLE
update useSelector() ts example in API Reference

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -47,7 +47,7 @@ From there, you may import any of the listed React Redux hooks APIs and use them
 ```ts
 type RootState = ReturnType<typeof store.getState>
 type SelectorFn = <Selected>(state: RootState) => Selected
-type EqualityFn = (a: any, b: any) => boolean
+type EqualityFn = <Selected>(a: Selected, b: Selected) => boolean
 export type DevModeCheckFrequency = 'never' | 'once' | 'always'
 
 interface UseSelectorOptions {
@@ -59,8 +59,8 @@ interface UseSelectorOptions {
 }
 
 const result: Selected = useSelector(
-  selector: SelectorFunction,
-  options?: EqualityFn | UseSelectorOptions
+  selector: SelectorFn,
+  equalityFnOrOptions?: EqualityFn | UseSelectorOptions
 )
 ```
 


### PR DESCRIPTION
[The Hooks API Reference](https://react-redux.js.org/api/hooks#useselector) provides a simplified typescript definition for `useSelector()`  that defines a type alias for `SelectorFn`, but then uses `SelectorFunction` in place of that type later in the example. This PR replaces the `SelectorFunction` usage with `SelectorFn`, and adds a generic type parameter to `EqualityFn` to resemble the definition of `SelectorFn` more closely, and updates the name of the equalityFn parameter to equalityFnOrOptions to match its current name in v8.

The example also puts an assignment statement `const result: Selected =` before a function declaration for `useSelector`, which is technically invalid typescript. Its meaning is clear, but it does not match how other hook API functions with parameters like `createStoreHook`, `createDispatchHook`, and `createSelectorHook` are introduced in the docs. With this in mind, it may be better to provide the type definition for `useSelector` in the example, and put the assignment statement in an inline comment instead:

```ts
type RootState = ReturnType<typeof store.getState>
type SelectorFn = <Selected>(state: RootState) => Selected
type EqualityFn = <Selected>(a: Selected, b: Selected) => boolean
export type DevModeCheckFrequency = 'never' | 'once' | 'always'

interface UseSelectorOptions {
  equalityFn?: EqualityFn
  devModeChecks?: {
    stabilityCheck?: DevModeCheckFrequency
    identityFunctionCheck?: DevModeCheckFrequency
  }
}

export const useSelector: <Selected>(
  selector: SelectorFn,
  equalityFnOrOptions?: EqualityFn | UseSelectorOptions
) => Selected

// Example usage:
// const result: Selected = useSelector(selector, equalityFnOrOptions)
```


Issue: https://github.com/reduxjs/react-redux/issues/2152