### PR TITLE
Remove `no-resolution` flag and add `--exclude-entrypoints` when running `are-the-types-wrong` during CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,8 @@ jobs:
           path: .
 
       # Note: We currently expect "FalseCJS" failures for Node16 + `moduleResolution: "node16",
-      # and the `/alternateRenderers" entry point will not resolve under Node10.
-      # Skipping these is dangerous, but we'll leave it for now.
       - name: Run are-the-types-wrong
-        run: npx @arethetypeswrong/cli ./package.tgz --format table --ignore-rules false-cjs no-resolution
+        run: npx @arethetypeswrong/cli ./package.tgz --format table --ignore-rules false-cjs --exclude-entrypoints alternate-renderers
 
   test-published-artifact:
     name: Test Published Artifact ${{ matrix.example }}


### PR DESCRIPTION
`@arethetypeswrong/cli` now has an `--exclude-entrypoints` flag which we can use to exclude the `alternate-renderers` entrypoint from the check since it will fail under the `Node10` module resolution as `Node10` looks at actual files on disk and we don't have a file named `alternate-renderers`.