### PR TITLE
Fix `useIsomorphicLayoutEffect` usage in React Native environments

### DIFF
--- a/src/utils/useIsomorphicLayoutEffect.native.ts
+++ b/src/utils/useIsomorphicLayoutEffect.native.ts
@@ -1,5 +1,0 @@
-import { React } from '../utils/react'
-
-// Under React Native, we know that we always want to use useLayoutEffect
-
-export const useIsomorphicLayoutEffect = React.useLayoutEffect

--- a/src/utils/useIsomorphicLayoutEffect.ts
+++ b/src/utils/useIsomorphicLayoutEffect.ts
@@ -16,6 +16,18 @@ export const canUseDOM = !!(
   typeof window.document.createElement !== 'undefined'
 )
 
+// Under React Native, we know that we always want to use useLayoutEffect
+
+/**
+ * Checks if the code is running in a React Native environment.
+ *
+ * @see {@link https://github.com/facebook/react-native/issues/1331 Reference}
+ */
+export const isReactNative =
+  typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
+
 export const useIsomorphicLayoutEffect = canUseDOM
   ? React.useLayoutEffect
-  : React.useEffect
+  : isReactNative
+    ? React.useLayoutEffect
+    : React.useEffect

--- a/src/utils/useIsomorphicLayoutEffect.ts
+++ b/src/utils/useIsomorphicLayoutEffect.ts
@@ -26,8 +26,5 @@ export const canUseDOM = !!(
 export const isReactNative =
   typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
 
-export const useIsomorphicLayoutEffect = canUseDOM
-  ? React.useLayoutEffect
-  : isReactNative
-    ? React.useLayoutEffect
-    : React.useEffect
+export const useIsomorphicLayoutEffect =
+  canUseDOM || isReactNative ? React.useLayoutEffect : React.useEffect


### PR DESCRIPTION
## __Overview__

It looks like React Native was not using `useLayoutEffect` which was causing nested component updates to not get properly batched when using the `connect` API. 

## __This PR__:

  - [X] Fixes `useIsomorphicLayoutEffect` usage in React Native environments. 
  - [X] Fixes #2150.
  
Possible related issues: #1313, #1444, #1510, #1436.
  
I did test the actual build with `yalc`, React Native, Expo and Expo web seem to be working properly. We can probably get rid of [`src/utils/useIsomorphicLayoutEffect.native.ts`](https://github.com/reduxjs/react-redux/blob/master/src/utils/useIsomorphicLayoutEffect.native.ts) file, so let me know if you want me to do that I can include it in this PR or a separate one.