### PR TITLE
Replace usage of deprecated `JSX` global namespace with `React.JSX`

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -651,7 +651,9 @@ function connect<
       /**
        * @todo Change this to `React.useRef<Error>(undefined)` after upgrading to React 19.
        */
-      const latestSubscriptionCallbackError = React.useRef<Error | undefined>(undefined)
+      const latestSubscriptionCallbackError = React.useRef<Error | undefined>(
+        undefined,
+      )
 
       useIsomorphicLayoutEffect(() => {
         isMounted.current = true
@@ -756,11 +758,11 @@ function connect<
       const renderedWrappedComponent = React.useMemo(() => {
         return (
           // @ts-ignore
-          (<WrappedComponent
+          <WrappedComponent
             {...actualChildProps}
             ref={reactReduxForwardedRef}
-          />)
-        );
+          />
+        )
       }, [reactReduxForwardedRef, WrappedComponent, actualChildProps])
 
       // If React sees the exact same element reference as last time, it bails out of re-rendering

--- a/test/components/Provider.spec.tsx
+++ b/test/components/Provider.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch } from 'react'
+import type { Dispatch, JSX } from 'react';
 import React, { Component } from 'react'
 import type { Store } from 'redux'
 import { createStore } from 'redux'

--- a/test/components/Provider.spec.tsx
+++ b/test/components/Provider.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch, JSX } from 'react';
+import type { Dispatch, JSX } from 'react'
 import React, { Component } from 'react'
 import type { Store } from 'redux'
 import { createStore } from 'redux'

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch, ElementType, MouseEvent, ReactNode, JSX } from 'react';
+import type { Dispatch, ElementType, MouseEvent, ReactNode, JSX } from 'react'
 import React, { Component } from 'react'
 import type {
   Action,

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -1,7 +1,7 @@
 /*eslint-disable react/prop-types*/
 
 import * as rtl from '@testing-library/react'
-import type { Dispatch, ElementType, MouseEvent, ReactNode } from 'react'
+import type { Dispatch, ElementType, MouseEvent, ReactNode, JSX } from 'react';
 import React, { Component } from 'react'
 import type {
   Action,


### PR DESCRIPTION
## This PR:

  - [X] Runs `npx types-react-codemod scoped-jsx .` to replace usage of the deprecated `JSX` global namespace with `React.JSX` in preparation for React 19.
  
### Relevant Links:
  
  - [The `JSX` namespace in TypeScript](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript)
  - [`scoped-jsx` codemod](https://github.com/eps1lon/types-react-codemod/?tab=readme-ov-file#scoped-jsx)