### PR TITLE
Fix `useRef` usages to be called with an explicit argument of `undefined`.

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -647,7 +647,11 @@ function connect<
       const renderIsScheduled = React.useRef(false)
       const isMounted = React.useRef(false)
 
-      const latestSubscriptionCallbackError = React.useRef<Error>(undefined)
+      // TODO: Change this to `React.useRef<Error>(undefined)` after upgrading to React 19.
+      /**
+       * @todo Change this to `React.useRef<Error>(undefined)` after upgrading to React 19.
+       */
+      const latestSubscriptionCallbackError = React.useRef<Error | undefined>(undefined)
 
       useIsomorphicLayoutEffect(() => {
         isMounted.current = true

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -641,13 +641,13 @@ function connect<
       }, [didStoreComeFromProps, contextValue, subscription])
 
       // Set up refs to coordinate values between the subscription effect and the render logic
-      const lastChildProps = React.useRef<unknown>()
+      const lastChildProps = React.useRef<unknown>(undefined)
       const lastWrapperProps = React.useRef(wrapperProps)
-      const childPropsFromStoreUpdate = React.useRef<unknown>()
+      const childPropsFromStoreUpdate = React.useRef<unknown>(undefined)
       const renderIsScheduled = React.useRef(false)
       const isMounted = React.useRef(false)
 
-      const latestSubscriptionCallbackError = React.useRef<Error>()
+      const latestSubscriptionCallbackError = React.useRef<Error>(undefined)
 
       useIsomorphicLayoutEffect(() => {
         isMounted.current = true
@@ -752,11 +752,11 @@ function connect<
       const renderedWrappedComponent = React.useMemo(() => {
         return (
           // @ts-ignore
-          <WrappedComponent
+          (<WrappedComponent
             {...actualChildProps}
             ref={reactReduxForwardedRef}
-          />
-        )
+          />)
+        );
       }, [reactReduxForwardedRef, WrappedComponent, actualChildProps])
 
       // If React sees the exact same element reference as last time, it bails out of re-rendering


### PR DESCRIPTION
## This PR:

  - [X] Runs `npx types-react-codemod useRef-required-initial .` to fix `useRef` usages to be called with an explicit argument of `undefined` in preparation for React 19.
  
  ### Relevant Links:
  
  - [`useRef` requires an argument](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument)
  - [`useRef-required-initial` codemod](https://github.com/eps1lon/types-react-codemod/?tab=readme-ov-file#useref-required-initial)