### PR TITLE
Drop now-unneeded RN peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,14 +52,10 @@
   "peerDependencies": {
     "@types/react": "^18.2.25",
     "react": "^18.0",
-    "react-native": ">=0.69",
     "redux": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
-      "optional": true
-    },
-    "react-native": {
       "optional": true
     },
     "redux": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7158,12 +7158,9 @@ __metadata:
   peerDependencies:
     "@types/react": ^18.2.25
     react: ^18.0
-    react-native: ">=0.69"
     redux: ^5.0.0
   peerDependenciesMeta:
     "@types/react":
-      optional: true
-    react-native:
       optional: true
     redux:
       optional: true


### PR DESCRIPTION
We listed React Native as a peer dep because we needed to import `unstable_batchedUpdates`.  

We no longer depend on that at all since React batches natively, and we don't have a single `"react-native"` reference in the source. 

This is ultimately the reason why NPM is blowing up with peer dep mismatches, so dropping that peer dep listing _should_ hopefully fix things.