### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,11 @@ jobs:
         run: yarn add ./package.tgz
 
       - name: Erase path aliases
-        run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json ./vitest.config.mts
+        run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json
 
       - name: Test types
+        env:
+          TEST_DIST: true
         run: |
           yarn tsc --version
           yarn type-tests
@@ -264,7 +266,9 @@ jobs:
         run: yarn add ./package.tgz
 
       - name: Erase path aliases
-        run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json ./vitest.config.mts
+        run: sed -i -e /@remap-prod-remove-line/d ./tsconfig.base.json
 
       - name: Run local tests against the build artifact
+        env:
+          TEST_DIST: true
         run: yarn test

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,10 @@ export default defineConfig({
     setupFiles: ['test/setup.ts'],
     globals: true,
     alias: {
-      'react-redux': new URL('src/index.ts', import.meta.url).pathname, // @remap-prod-remove-line
+      'react-redux': new URL(
+        process.env.TEST_DIST ? 'node_modules/react-redux' : 'src/index.ts',
+        import.meta.url,
+      ).pathname,
       // this mapping is disabled as we want `dist` imports in the tests only to be used for "type-only" imports which don't play a role for jest
       '@internal': new URL('src', import.meta.url).pathname,
     },


### PR DESCRIPTION
## **Overview**

It seems like the new version of Vite much like Node.js allows packages to self-reference themselves, which became a problem considering how we were running the tests against the build artifact during CI. The main issue was that when running the tests against the build artifact, Vitest was prioritizing the `react-redux` source files instead of the external `react-redux` inside the `node_modules` folder.