### PR TITLE
Drop `@types/react` peer dependency from `^18.2.25` to `^18.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "coverage": "codecov"
   },
   "peerDependencies": {
-    "@types/react": "^18.2.25",
+    "@types/react": "^18.0",
     "react": "^18.0",
     "redux": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6395,7 +6395,7 @@ __metadata:
     use-sync-external-store: "npm:^1.2.2"
     vitest: "npm:^1.6.0"
   peerDependencies:
-    "@types/react": ^18.2.25
+    "@types/react": ^18.0
     react: ^18.0
     redux: ^5.0.0
   peerDependenciesMeta:


### PR DESCRIPTION
## Overview

According to the DefinitelyTyped project FAQ [here](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library),  `@types` dependencies should align with the MAJOR.MINOR of the source project, while the PATCH version is managed independently.

> Because the version is listed as 20.8.9999, the npm version of the @types/node package will also be 20.8.x. Note that the version in package.json should only contain major.minor version (e.g. 10.12) followed by .9999. This is because only the major and minor release numbers are aligned between library packages and type declaration packages. 

This alignment helps prevent dependency duplication in the `node_modules` folder, particularly for projects using pinned or tilde versions.

Below is an example of a project with the `@types/react` dependency version lower than the one required by the current `react-redux` project peer dependency.
This is the output of running `yarn install`:

![Screenshot 2024-11-26 at 16 16 25](https://github.com/user-attachments/assets/6a34616c-6544-40c7-8e15-570c4bdd842b)

Here is is the output of running `yarn explain peer-requirements <hash>`:

![Screenshot 2024-11-26 at 16 32 07](https://github.com/user-attachments/assets/baf7ca33-2222-4cdc-b0a8-005ac0eb65dd)

This output advises the user to update their dependencies to match those required by `react-redux` in order to avoid duplication.

## This PR

- drops `@types/react` peer dependency from `^18.2.25` to `^18.0`