### PR TITLE
[DRAFT] Prototype proxy-based shallow equality selector perf optimization

### DIFF
--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,6 +1,6 @@
 //import * as React from 'react'
 import { React } from '../utils/react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
+import { useSyncExternalStoreWithSelector } from './useSyncExternalStoreWithSelector'
 import type { ReactReduxContextValue } from '../components/Context'
 import { ReactReduxContext } from '../components/Context'
 import type { EqualityFn, NoInfer } from '../types'

--- a/src/hooks/useSyncExternalStoreWithSelector.ts
+++ b/src/hooks/useSyncExternalStoreWithSelector.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import is from '../utils/shallowEqual'
-import { useSyncExternalStore } from 'use-sync-external-store'
+import { useSyncExternalStore } from 'react'
 
 // Intentionally not using named imports because Rollup uses dynamic dispatch
 // for CommonJS interop.

--- a/src/hooks/useSyncExternalStoreWithSelector.ts
+++ b/src/hooks/useSyncExternalStoreWithSelector.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import is from '../utils/shallowEqual'
+import { is } from '../utils/shallowEqual'
 import { useSyncExternalStore } from 'react'
 
 // Intentionally not using named imports because Rollup uses dynamic dispatch

--- a/src/hooks/useSyncExternalStoreWithSelector.ts
+++ b/src/hooks/useSyncExternalStoreWithSelector.ts
@@ -1,0 +1,193 @@
+import * as React from 'react'
+import is from '../utils/shallowEqual'
+import { useSyncExternalStore } from 'use-sync-external-store'
+
+// Intentionally not using named imports because Rollup uses dynamic dispatch
+// for CommonJS interop.
+const { useRef, useEffect, useMemo, useDebugValue } = React
+// Same as useSyncExternalStore, but supports selector and isEqual arguments.
+export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  getServerSnapshot: void | null | (() => Snapshot),
+  selector: (snapshot: Snapshot) => Selection,
+  isEqual?: (a: Selection, b: Selection) => boolean,
+): Selection {
+  // Use this to track the rendered snapshot.
+  const instRef = useRef<
+    | {
+        hasValue: true
+        value: Selection
+      }
+    | {
+        hasValue: false
+        value: null
+      }
+    | null
+  >(null)
+  let inst
+
+  if (instRef.current === null) {
+    inst = {
+      hasValue: false,
+      value: null,
+    }
+    // @ts-ignore
+    instRef.current = inst
+  } else {
+    inst = instRef.current
+  }
+
+  const [getSelection, getServerSelection] = useMemo(() => {
+    // Track the memoized state using closure variables that are local to this
+    // memoized instance of a getSnapshot function. Intentionally not using a
+    // useRef hook, because that state would be shared across all concurrent
+    // copies of the hook/component.
+    let hasMemo = false
+    let memoizedSnapshot: Snapshot
+    let memoizedSelection: Selection
+    let lastUsedProps: string[] = []
+    let hasAccessed = false
+    const accessedProps: string[] = []
+
+    const memoizedSelector = (nextSnapshot: Snapshot) => {
+      const getProxy = (): Snapshot => {
+        if (
+          !(typeof nextSnapshot === 'object') ||
+          typeof Proxy === 'undefined'
+        ) {
+          return nextSnapshot
+        }
+
+        const handler = {
+          get: (target: Snapshot, prop: string, receiver: any) => {
+            const propertyName = prop.toString()
+
+            if (accessedProps.indexOf(propertyName) === -1) {
+              accessedProps.push(propertyName)
+            }
+
+            const value = Reflect.get(target as any, prop, receiver)
+            return value
+          },
+        }
+        return new Proxy(nextSnapshot as any, handler) as any
+      }
+
+      if (!hasMemo) {
+        // The first time the hook is called, there is no memoized result.
+        hasMemo = true
+        memoizedSnapshot = nextSnapshot
+        const nextSelection = selector(getProxy())
+        lastUsedProps = accessedProps
+        hasAccessed = true
+
+        if (isEqual !== undefined) {
+          // Even if the selector has changed, the currently rendered selection
+          // may be equal to the new selection. We should attempt to reuse the
+          // current value if possible, to preserve downstream memoizations.
+          if (inst.hasValue) {
+            const currentSelection = inst.value
+
+            if (isEqual(currentSelection as Selection, nextSelection)) {
+              memoizedSelection = currentSelection as Selection
+              return currentSelection
+            }
+          }
+        }
+
+        memoizedSelection = nextSelection
+        return nextSelection
+      }
+
+      // We may be able to reuse the previous invocation's result.
+      const prevSnapshot = memoizedSnapshot
+      const prevSelection = memoizedSelection
+
+      const getChangedSegments = (): string[] | void => {
+        if (
+          prevSnapshot === undefined ||
+          !hasAccessed ||
+          lastUsedProps.length === 0
+        ) {
+          return undefined
+        }
+
+        const result: string[] = []
+
+        if (
+          nextSnapshot !== null &&
+          typeof nextSnapshot === 'object' &&
+          prevSnapshot !== null &&
+          typeof prevSnapshot === 'object'
+        ) {
+          for (let i = 0; i < lastUsedProps.length; i++) {
+            const segmentName = lastUsedProps[i]
+
+            if (
+              (nextSnapshot as Record<string, unknown>)[segmentName] !==
+              (prevSnapshot as Record<string, unknown>)[segmentName]
+            ) {
+              result.push(segmentName)
+            }
+          }
+        }
+
+        return result
+      }
+
+      if (is(prevSnapshot, nextSnapshot)) {
+        // The snapshot is the same as last time. Reuse the previous selection.
+        return prevSelection
+      }
+
+      // The snapshot has changed, so we need to compute a new selection.
+      const changedSegments = getChangedSegments()
+
+      if (changedSegments === undefined || changedSegments.length > 0) {
+        const nextSelection = selector(getProxy())
+        lastUsedProps = accessedProps
+        hasAccessed = true
+
+        // If a custom isEqual function is provided, use that to check if the data
+        // has changed. If it hasn't, return the previous selection. That signals
+        // to React that the selections are conceptually equal, and we can bail
+        // out of rendering.
+        if (isEqual !== undefined && isEqual(prevSelection, nextSelection)) {
+          return prevSelection
+        }
+
+        memoizedSnapshot = nextSnapshot
+        memoizedSelection = nextSelection
+        return nextSelection
+      } else {
+        return prevSelection
+      }
+    }
+
+    // Assigning this to a constant so that Flow knows it can't change.
+    const maybeGetServerSnapshot =
+      getServerSnapshot === undefined ? null : getServerSnapshot
+
+    const getSnapshotWithSelector = () => memoizedSelector(getSnapshot())
+
+    const getServerSnapshotWithSelector =
+      maybeGetServerSnapshot === null
+        ? undefined
+        : () => memoizedSelector(maybeGetServerSnapshot())
+    return [getSnapshotWithSelector, getServerSnapshotWithSelector]
+  }, [getSnapshot, getServerSnapshot, selector, isEqual])
+  const value = useSyncExternalStore(
+    subscribe,
+    getSelection,
+    getServerSelection,
+  )
+  useEffect(() => {
+    // $FlowFixMe[incompatible-type] changing the variant using mutation isn't supported
+    inst.hasValue = true
+    // $FlowFixMe[incompatible-type]
+    inst.value = value
+  }, [value])
+  useDebugValue(value)
+  return value as Selection
+}

--- a/src/utils/shallowEqual.ts
+++ b/src/utils/shallowEqual.ts
@@ -1,4 +1,4 @@
-function is(x: unknown, y: unknown) {
+export function is(x: unknown, y: unknown) {
   if (x === y) {
     return x !== 0 || y !== 0 || 1 / x === 1 / y
   } else {

--- a/test/hooks/useSelector.spec.tsx
+++ b/test/hooks/useSelector.spec.tsx
@@ -443,7 +443,7 @@ describe('React', () => {
           expect(renderedItems.length).toEqual(2)
         })
 
-        it.only('only calls selectors if the state they depend on has changed', () => {
+        it('only calls selectors if the state they depend on has changed', () => {
           const sliceA = createSlice({
             name: 'a',
             initialState: 0,


### PR DESCRIPTION
## Summary

This PR:

- Copy-pastes the `useSyncExternalStoreWithSelector` method from the `use-sync-external-store` package and converts it to TS
- Updates `useSelector` to use our inlined version
- Applies the modifications from https://github.com/facebook/react/pull/32040 , which:
  - Track root-state-level selector field accesses via a Proxy
  - Upon updates, do comparisons of those fields in the old and new state to determine if any of the read fields changed
  - Only re-run the selector if a read field changed

The intent is to improve app-wide selector performance by skipping selectors that are unlikely to be producing a new result.

## Background

React and Redux have always been "80%" solutions. They work fine in most cases, but they aren't the most optimized option perf-wise, and it takes work to squeeze out extra perf.

Redux is by definition an O(n) subscription setup. N selected components means N subscriber callbacks and selectors run on every dispatch. This is fine with hundreds of connected components, but as it gets into the thousands, this can become noticeable overhead.

### Auto-Tracking Experiment

2 years ago I very briefly played with the idea of trying to Proxy-wrap selectors - first in Reselect, then in React-Redux:

- https://github.com/reduxjs/react-redux/pull/2047

That was a single 4-hour in-flight hacking session. I reused a bunch of "auto-tracking" code from the Ember world.  The idea was:

- keep a single Proxy-wrapped root state copy at the top of the component tree, pass down in the subscription
- any selectors accessing that force creation of nested auto-tracking for every touched field
- when a store update happens, we do an immutable-reconciliation thingy with the state copy and mark fields as dirty
- then by the time we run subscribers, we know if the fields they last read got updated or not, and could smartly bail out of even running the selectors

My thought was that we'd ship some opt-in approach (param for `<Provider>` or an alternate impl, plus a specific `useTrackedSelector` hook), to avoid the runtime and bundle overhead unless you wanted it.

The bigger question was whether the cost of doing that tracking + reconciliation would be less than the cost of skipping the subscribers.

My quick hack session got _something_ sorta-kinda working and some tests passing, but also looked like the perf cost of doing that work could be awfully expensive.

### More Research

Since then I've kept an eye out for signals libraries that looked like they might be useful (and still have several ideas I want to play with there at some point).

However, I also saw a relevant PR earlier this year:

- https://github.com/facebook/react/pull/32040

This directly changed `useSyncExternalStoreWithSelector` to do shallow root field comparisons, rather than trying to do deep nested tracking.

Based on some conversations I've had with folks who had very complex Redux apps (20K+ connected components), it sounded like just bailing out of irrelevant first-level state changes could be a decent bang for the buck.

That PR got closed, so I figured I'd try porting the changes to React-Redux to try them out.

### Status

At the moment, all our existing tests pass.  I've run some local checks on the existing https://github.com/reduxjs/react-redux-benchmarks using the new version, and it seems generally equivalent so far.  At least it's not _worse_, but also not sure it's actually helping improve that much.

I'll have to do some more perf testing and get a better sense of whether it actually is helping or not.

Not sure what a final productionized form might look like. I'm not terribly keen on either fully forking `uSESWS`, or flat-out changing `useSelector` to use the new behavior all the time.  I could imagine it being a new hook instead, so you'd have to explicitly import it and use it intentionally.  It's also entirely possible this is just a questionable line of research to start with, and not worth shipping.