### PR TITLE
Updated  initialization to avoid using  syntax for better compatibility.

### DIFF
--- a/src/components/Context.ts
+++ b/src/components/Context.ts
@@ -28,10 +28,14 @@ const gT: {
 function getContext(): Context<ReactReduxContextValue | null> {
   if (!React.createContext) return {} as any
 
-  const contextMap = (gT[ContextKey] ??= new Map<
-    typeof React.createContext,
-    Context<ReactReduxContextValue | null>
-  >())
+  let contextMap = gT[ContextKey];
+  if (!contextMap) {
+    contextMap = new Map<
+      typeof React.createContext,
+      Context<ReactReduxContextValue | null>
+    >();
+    gT[ContextKey] = contextMap;
+  }
   let realContext = contextMap.get(React.createContext)
   if (!realContext) {
     realContext = React.createContext<ReactReduxContextValue | null>(

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -535,7 +535,7 @@ function connect<
         // Users may optionally pass in a custom context instance to use instead of our ReactReduxContext.
         // Memoize the check that determines which context instance we should use.
         let ResultContext = Context
-        if (propsContext?.Consumer) {
+        if (propsContext && propsContext.Consumer) {
           if (process.env.NODE_ENV !== 'production') {
             const isValid = /*#__PURE__*/ isContextConsumer(
               // @ts-ignore


### PR DESCRIPTION
**Problem:**
React Native 0.80, when running without enabling Hermes or the New Architecture, does not support the `??` (nullish coalescing assignment) or `?.` (optional chaining) operators. This causes compatibility issues and can lead to application crashes in environments where these features are not supported.

**Solution:**
Updated the code to replace `??=` and `?.` operators with more compatible traditional syntax (`if` checks). This ensures the code works seamlessly in React Native 0.80 environments without requiring Hermes or the New Architecture to be enabled.

**Changes:**
- Replaced `??=` in Context.ts with `if` checks for nullish values.
- Replaced `?.` in `connect.tsx` with traditional `if` checks for property existence.

**Impact:**
This change improves compatibility and prevents crashes in React Native 0.80 environments that do not use Hermes or the New Architecture. It ensures the codebase remains stable across different configurations.

**Testing:**
- Verified the updated code works correctly in environments with and without Hermes/New Architecture enabled.
- Ensured no functionality was broken by the changes.

This PR makes the codebase more robust and compatible with a wider range of React Native setups.