### PR TITLE
Don't override ref property when not configured to.

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -747,11 +747,14 @@ function connect<
       // Now that all that's done, we can finally try to actually render the child component.
       // We memoize the elements for the rendered child component as an optimization.
       const renderedWrappedComponent = React.useMemo(() => {
+        const effectiveProps = {...actualChildProps};
+        if (forwardRef) {
+          effectiveProps.ref = reactReduxForwardedRef
+        }
         return (
           // @ts-ignore
           <WrappedComponent
-            {...actualChildProps}
-            ref={reactReduxForwardedRef}
+            {...effectiveProps}
           />
         )
       }, [reactReduxForwardedRef, WrappedComponent, actualChildProps])

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -2602,7 +2602,9 @@ describe('React', () => {
           RefReceiverNoDispatchType,
           RefReceiverPropsType,
           RootStateType
-        >(null, null)
+        >(null, null, null, {
+          forwardRef: IS_REACT_18
+        })
         const DecoratedRefReceiver = decorator(RefReceiver)
         const testRef = React.createRef<HTMLSpanElement>()
         rtl.render(

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -2588,6 +2588,25 @@ describe('React', () => {
 
         expect(tester.getByTestId('a')).toHaveTextContent('42')
       })
+
+      it('should not override ref property when not asked to.', async () => {
+        const store = createStore(() => ({}))
+        interface RefReceiverProps {
+          ref: React.Ref<HTMLSpanElement | null>
+        }
+        function RefReceiver(props: RefReceiverProps) {
+          const {ref} = props
+          return <span ref={ref} />
+        }
+        const DecoratedRefReceiver = connect()(RefReceiver)
+        const testRef = React.createRef<HTMLSpanElement>()
+        rtl.render(
+          <ProviderMock store={store}>
+            <DecoratedRefReceiver ref={testRef} />
+          </ProviderMock>
+        )
+        expect(testRef.current).toBeInstanceOf(HTMLSpanElement);
+      })
     })
 
     describe('Factory functions for mapState/mapDispatch', () => {

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -2590,15 +2590,20 @@ describe('React', () => {
       })
 
       it('should not override ref property when not asked to.', async () => {
+        type RootStateType = {}
         const store = createStore(() => ({}))
-        interface RefReceiverProps {
-          ref: React.Ref<HTMLSpanElement | null>
-        }
-        function RefReceiver(props: RefReceiverProps) {
-          const {ref} = props
-          return <span ref={ref} />
-        }
-        const DecoratedRefReceiver = connect()(RefReceiver)
+        type RefReceiverPropsType = {}
+        const RefReceiver = React.forwardRef<HTMLSpanElement, RefReceiverPropsType>(
+          (props: RefReceiverPropsType, ref) => <span ref={ref} />
+        );
+        type RefReceiverNoDispatchType = null
+        const decorator = connect<
+          RefReceiverPropsType,
+          RefReceiverNoDispatchType,
+          RefReceiverPropsType,
+          RootStateType
+        >(null, null)
+        const DecoratedRefReceiver = decorator(RefReceiver)
         const testRef = React.createRef<HTMLSpanElement>()
         rtl.render(
           <ProviderMock store={store}>


### PR DESCRIPTION
The current behavior of `connect` is to always pass along a ref property, event when the option `forwardRef` was not truthy or preset.

This pull request 
* corrects this error by only forwarding a ref property when actually configured to.
* avoids problems, when accessing the forwarded but always `undefined` ref.
* fixes #2251

The error in the following use case is also fixed with this pull-request:
```
import WrappedComponent from '...'
function HocComponent(props) {
   const [wrapperRef, setRef] = useState(null)
   // The current behavior of connect would override the ref!
   return <WrappedComponent ref={setRef} {...props} />
}
export default connect(...)(HocComponent)
```

_NOTE:_ 
My initial intend was to remove the use of `React.forwardRef(...)` completely, but this would have broken the compatibility with React prior to version 19.