### PR TITLE
Update NO_SUBSCRIPTION_ARRAY in connect.tsx

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -41,7 +41,7 @@ import { ReactReduxContext } from './Context'
 
 // Define some constant arrays just to avoid re-creating these
 const EMPTY_ARRAY: [unknown, number] = [null, 0]
-const NO_SUBSCRIPTION_ARRAY = [null, null]
+const NO_SUBSCRIPTION_ARRAY = [null, null] as [Subscription, VoidFunction]
 
 // Attempts to stringify whatever not-really-a-component value we were given
 // for logging in an error message

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -41,7 +41,7 @@ import { ReactReduxContext } from './Context'
 
 // Define some constant arrays just to avoid re-creating these
 const EMPTY_ARRAY: [unknown, number] = [null, 0]
-const NO_SUBSCRIPTION_ARRAY = [null, null] as [Subscription, VoidFunction]
+const NO_SUBSCRIPTION_ARRAY = [null, null] as unknown as [Subscription, VoidFunction]
 
 // Attempts to stringify whatever not-really-a-component value we were given
 // for logging in an error message


### PR DESCRIPTION
Accessing 'connect.tsx' from my legacy component is causing my `tsc` command to error with:

```
Variable 'NO_SUBSCRIPTION_ARRAY' implicitly has an 'any[]' type
```

This is due to my `noImplicitAny` configuration. I'm already excluding `node_modules` but the direct access to `connect.tsx` makes `tsc` type check the library.

The `skipLibCheck` config will only ignore a `.d.ts` file, never a `.tsx` ( [TypeScript issue#41883](https://github.com/microsoft/TypeScript/issues/41883#issuecomment-1758692340))

Updating NO_SUBSCRIPTION_ARRAY in `connect.tsx` seems like the logical best fix.