### PR TITLE
fix(`connect`): log `mapStateToProps` errors to `console.error` in dev (#1942)

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -103,6 +103,7 @@ function subscribeUpdates(
   notifyNestedSubs: () => void,
   // forceComponentUpdateDispatch: React.Dispatch<any>,
   additionalSubscribeListener: () => void,
+  displayName: string,
 ) {
   // If we're not subscribed to the store, nothing to do here
   if (!shouldHandleStateChanges) return () => {}
@@ -135,7 +136,7 @@ function subscribeUpdates(
       lastThrownError = e as Error | null
       if (process.env.NODE_ENV !== 'production') {
         console.error(
-          'An error occurred in `mapStateToProps` (or a selector) of a `connect()`-ed component. ' +
+          `An error occurred in \`mapStateToProps\` (or a selector) of the \`connect()\`-ed component "${displayName}". ` +
             'See https://github.com/reduxjs/react-redux/issues/1942 for details.',
           e,
         )
@@ -719,6 +720,7 @@ function _connect<
             childPropsFromStoreUpdate,
             notifyNestedSubs,
             reactListener,
+            displayName,
           )
         }
 

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -133,6 +133,13 @@ function subscribeUpdates(
     } catch (e) {
       error = e
       lastThrownError = e as Error | null
+      if (process.env.NODE_ENV !== 'production') {
+        console.error(
+          'An error occurred in `mapStateToProps` (or a selector) of a `connect()`-ed component. ' +
+            'See https://github.com/reduxjs/react-redux/issues/1942 for details.',
+          e,
+        )
+      }
     }
 
     if (!error) {

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -287,7 +287,8 @@ describe('React', () => {
         })
 
         consoleSpy.mockRestore()
-        process.env.NODE_ENV = originalNodeEnv
+
+        vi.unstubAllEnvs()
       })
 
       it("should retain the store's context", () => {

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -221,6 +221,12 @@ describe('React', () => {
       })
 
       it('should log errors thrown in mapStateToProps to console.error in development (#1942)', () => {
+        // The dev log is gated behind `process.env.NODE_ENV !== 'production'`.
+        // Pin it to 'development' so the test exercises the dev branch explicitly
+        // rather than relying on the test runner's ambient env.
+        const originalNodeEnv = process.env.NODE_ENV
+        process.env.NODE_ENV = 'development'
+
         const store: Store = createStore(stringBuilder)
 
         // Throw on the first call only. The subscription-update path catches
@@ -268,6 +274,16 @@ describe('React', () => {
         )
         expect(loggedAnError).toBe(true)
 
+        // The logged message should name the offending component so the
+        // developer can tell which `connect()`-ed component threw.
+        const namedTheComponent = newCalls.some((args) =>
+          args.some(
+            (arg) =>
+              typeof arg === 'string' && arg.includes('Connect(Container)'),
+          ),
+        )
+        expect(namedTheComponent).toBe(true)
+
         // Dispatch again so the subscription path runs a successful update,
         // which clears `lastThrownError` and prevents the unmount-time rethrow.
         rtl.act(() => {
@@ -275,6 +291,7 @@ describe('React', () => {
         })
 
         consoleSpy.mockRestore()
+        process.env.NODE_ENV = originalNodeEnv
       })
 
       it("should retain the store's context", () => {

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -220,6 +220,63 @@ describe('React', () => {
         expect(tester.getByTestId('string')).toHaveTextContent('ab')
       })
 
+      it('should log errors thrown in mapStateToProps to console.error in development (#1942)', () => {
+        const store: Store = createStore(stringBuilder)
+
+        // Throw on the first call only. The subscription-update path catches
+        // and logs the error; the subsequent re-render then succeeds, so the
+        // error does not propagate up to the test runner.
+        let shouldThrow = false
+        const mapState = (state: string) => {
+          if (shouldThrow) {
+            shouldThrow = false
+            throw new Error('mapStateToProps failed')
+          }
+          return { value: state }
+        }
+
+        class Container extends Component<{ value: string }> {
+          render() {
+            return <Passthrough {...this.props} />
+          }
+        }
+        const ConnectedContainer = connect(mapState)(Container)
+
+        const consoleSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {})
+
+        rtl.render(
+          <ProviderMock store={store}>
+            <ConnectedContainer />
+          </ProviderMock>,
+        )
+
+        const callsBeforeDispatch = consoleSpy.mock.calls.length
+
+        shouldThrow = true
+        rtl.act(() => {
+          store.dispatch({ type: 'APPEND', body: 'a' })
+        })
+
+        const newCalls = consoleSpy.mock.calls.slice(callsBeforeDispatch)
+        const loggedAnError = newCalls.some((args) =>
+          args.some(
+            (arg) =>
+              arg instanceof Error && arg.message === 'mapStateToProps failed',
+          ),
+        )
+        expect(loggedAnError).toBe(true)
+
+        // Dispatch again so the subscription path runs a successful update,
+        // which clears `lastThrownError` and prevents the unmount-time rethrow.
+        rtl.act(() => {
+          store.dispatch({ type: 'APPEND', body: 'b' })
+        })
+
+        consoleSpy.mockRestore()
+      })
+
       it("should retain the store's context", () => {
         const store = new ContextBoundStore(stringBuilder)
 

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -221,11 +221,7 @@ describe('React', () => {
       })
 
       it('should log errors thrown in mapStateToProps to console.error in development (#1942)', () => {
-        // The dev log is gated behind `process.env.NODE_ENV !== 'production'`.
-        // Pin it to 'development' so the test exercises the dev branch explicitly
-        // rather than relying on the test runner's ambient env.
-        const originalNodeEnv = process.env.NODE_ENV
-        process.env.NODE_ENV = 'development'
+        vi.stubEnv('NODE_ENV', 'development')
 
         const store: Store = createStore(stringBuilder)
 


### PR DESCRIPTION
## Summary

Logs errors thrown in `mapStateToProps` (or selectors) to `console.error`
in non-production environments, so they surface during development
instead of being silently swallowed.

Fixes #1942

## Background

Since v8.0.0, errors thrown inside `mapStateToProps` are caught in the
subscription callback ([connect.tsx#L133-L136][1]) and stored in
`lastThrownError`. In v7, those errors surfaced because the component
unmounted on selector errors (the unmount path re-throws
`lastThrownError`). In v8+, the component no longer unmounts — it just
re-renders in its pre-error state — so the error is silently swallowed.

This was diagnosed by @alexanderchr in
[#1942 (Dec 12, 2024)][2], and @markerikson approved the dev-only
logging approach in the [same thread][3]:

> "logging this in dev seems like a passable fallback"

## Changes

- `src/components/connect.tsx` — log the caught error to `console.error`
  when `process.env.NODE_ENV !== 'production'`, with a brief message and
  a link back to this issue
- `test/components/connect.spec.tsx` — add a unit test that dispatches
  an action which causes `mapStateToProps` to throw, then asserts the
  error was logged via `console.error`

## Behavior

- ✅ **Production**: unchanged (the new branch is dead-code-eliminated)
- ✅ **Development**: error is now logged to the console with the
  original error object, making it discoverable in DevTools

## Test plan

- [x] `yarn test` — all `connect` tests pass (65/65), new test passes,
  no regressions in code I touched
- [x] `yarn lint` runs as part of `pretest` and passes
- [x] Type-check passes (`vitest --typecheck` reports no errors)

[1]: https://github.com/reduxjs/react-redux/blob/master/src/components/connect.tsx#L133-L136
[2]: https://github.com/reduxjs/react-redux/issues/1942#issuecomment-2540022906
[3]: https://github.com/reduxjs/react-redux/issues/1942#issuecomment-2540097832
