### PR TITLE
feat: add dev stability checks to connect

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -38,6 +38,7 @@ import type {
   ReactReduxContextInstance,
 } from './Context'
 import { ReactReduxContext } from './Context'
+import type { DevModeCheckFrequency } from '../hooks/useSelector'
 
 // Define some constant arrays just to avoid re-creating these
 const EMPTY_ARRAY: [unknown, number] = [null, 0]
@@ -246,6 +247,8 @@ export interface ConnectOptions<
     nextMergedProps: TMergedProps,
     prevMergedProps: TMergedProps,
   ) => boolean
+
+  stabilityCheck?: DevModeCheckFrequency
 }
 
 /**
@@ -464,6 +467,7 @@ function _connect<
     areOwnPropsEqual = shallowEqual,
     areStatePropsEqual = shallowEqual,
     areMergedPropsEqual = shallowEqual,
+    stabilityCheck = 'never',
 
     // use React's forwardRef to expose a ref of the wrapped component
     forwardRef = false,
@@ -510,7 +514,7 @@ function _connect<
 
     const displayName = `Connect(${wrappedComponentName})`
 
-    const selectorFactoryOptions: SelectorFactoryOptions<
+    const baseSelectorFactoryOptions: SelectorFactoryOptions<
       any,
       any,
       any,
@@ -529,6 +533,7 @@ function _connect<
       areStatePropsEqual,
       areOwnPropsEqual,
       areMergedPropsEqual,
+      stabilityCheck,
     }
 
     function ConnectFunction<TOwnProps>(
@@ -602,7 +607,7 @@ function _connect<
       const childPropsSelector = React.useMemo(() => {
         // The child props selector needs the store reference as an input.
         // Re-create this selector whenever the store changes.
-        return defaultSelectorFactory(store.dispatch, selectorFactoryOptions)
+        return defaultSelectorFactory(store.dispatch, baseSelectorFactoryOptions)
       }, [store])
 
       const [subscription, notifyNestedSubs] = React.useMemo(() => {

--- a/src/connect/selectorFactory.ts
+++ b/src/connect/selectorFactory.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, Action } from 'redux'
 import type { ComponentType } from 'react'
+import type { DevModeCheckFrequency } from '../hooks/useSelector'
 import verifySubselectors from './verifySubselectors'
 import type { EqualityFn, ExtendedEqualityFn } from '../types'
 
@@ -62,6 +63,7 @@ interface PureSelectorFactoryComparisonOptions<TStateProps, TOwnProps, State> {
   readonly areStatesEqual: ExtendedEqualityFn<State, TOwnProps>
   readonly areStatePropsEqual: EqualityFn<TStateProps>
   readonly areOwnPropsEqual: EqualityFn<TOwnProps>
+  readonly stabilityCheck: DevModeCheckFrequency
 }
 
 function pureFinalPropsSelectorFactory<
@@ -79,19 +81,60 @@ function pureFinalPropsSelectorFactory<
     areStatesEqual,
     areOwnPropsEqual,
     areStatePropsEqual,
+    stabilityCheck,
   }: PureSelectorFactoryComparisonOptions<TStateProps, TOwnProps, State>,
 ) {
   let hasRunAtLeastOnce = false
+  let didStabilityCheckRun = false
   let state: State
   let ownProps: TOwnProps
   let stateProps: TStateProps
   let dispatchProps: TDispatchProps
   let mergedProps: TMergedProps
 
+  function checkStatePropsStability(nextState: State, nextOwnProps: TOwnProps) {
+    if (process.env.NODE_ENV === 'production') {
+      return
+    }
+
+    if (
+      stabilityCheck === 'never' ||
+      (stabilityCheck === 'once' && didStabilityCheckRun)
+    ) {
+      return
+    }
+
+    const secondStateProps = mapStateToProps(nextState, nextOwnProps)
+
+    if (!areStatePropsEqual(secondStateProps, stateProps)) {
+      let stack: string | undefined = undefined
+      try {
+        throw new Error()
+      } catch (e) {
+        // eslint-disable-next-line no-extra-semi
+        ;({ stack } = e as Error)
+      }
+
+      console.error(
+        'mapStateToProps returned a different result when called with the same inputs. This can lead to unnecessary rerenders.' +
+          '\nSelectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization',
+        {
+          state: nextState,
+          selected: stateProps,
+          selected2: secondStateProps,
+          stack,
+        },
+      )
+    }
+
+    didStabilityCheckRun = true
+  }
+
   function handleFirstCall(firstState: State, firstOwnProps: TOwnProps) {
     state = firstState
     ownProps = firstOwnProps
     stateProps = mapStateToProps(state, ownProps)
+    checkStatePropsStability(state, ownProps)
     dispatchProps = mapDispatchToProps(dispatch, ownProps)
     mergedProps = mergeProps(stateProps, dispatchProps, ownProps)
     hasRunAtLeastOnce = true
@@ -100,6 +143,7 @@ function pureFinalPropsSelectorFactory<
 
   function handleNewPropsAndNewState() {
     stateProps = mapStateToProps(state, ownProps)
+    checkStatePropsStability(state, ownProps)
 
     if (mapDispatchToProps.dependsOnOwnProps)
       dispatchProps = mapDispatchToProps(dispatch, ownProps)
@@ -112,6 +156,8 @@ function pureFinalPropsSelectorFactory<
     if (mapStateToProps.dependsOnOwnProps)
       stateProps = mapStateToProps(state, ownProps)
 
+    if (mapStateToProps.dependsOnOwnProps) checkStatePropsStability(state, ownProps)
+
     if (mapDispatchToProps.dependsOnOwnProps)
       dispatchProps = mapDispatchToProps(dispatch, ownProps)
 
@@ -123,6 +169,7 @@ function pureFinalPropsSelectorFactory<
     const nextStateProps = mapStateToProps(state, ownProps)
     const statePropsChanged = !areStatePropsEqual(nextStateProps, stateProps)
     stateProps = nextStateProps
+    checkStatePropsStability(state, ownProps)
 
     if (statePropsChanged)
       mergedProps = mergeProps(stateProps, dispatchProps, ownProps)

--- a/test/components/connect.spec.tsx
+++ b/test/components/connect.spec.tsx
@@ -220,6 +220,67 @@ describe('React', () => {
         expect(tester.getByTestId('string')).toHaveTextContent('ab')
       })
 
+      it('warns when mapStateToProps is unstable in development mode', () => {
+        const store = createStore(() => ({ count: 0 }))
+
+        const consoleSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {})
+
+        interface ContainerProps {
+          nested: {
+            count: number
+          }
+        }
+        function Container(props: ContainerProps) {
+          return <Passthrough {...props} />
+        }
+
+        const mapStateToProps = vi.fn((state: { count: number }) => ({
+          nested: { count: state.count },
+        }))
+
+        const ConnectedContainer = connect(
+          mapStateToProps,
+          undefined,
+          undefined,
+          {
+            stabilityCheck: 'once',
+          },
+        )(Container)
+
+        rtl.render(
+          <ProviderMock store={store}>
+            <ConnectedContainer />
+          </ProviderMock>,
+        )
+
+        expect(mapStateToProps).toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'returned a different result when called with the same inputs',
+          ),
+          expect.objectContaining({
+            state: expect.objectContaining({
+              count: 0,
+            }),
+            selected: expect.objectContaining({
+              nested: expect.objectContaining({
+                count: 0,
+              }),
+            }),
+            selected2: expect.objectContaining({
+              nested: expect.objectContaining({
+                count: 0,
+              }),
+            }),
+            stack: expect.any(String),
+          }),
+        )
+
+        consoleSpy.mockRestore()
+      })
+
       it("should retain the store's context", () => {
         const store = new ContextBoundStore(stringBuilder)
 


### PR DESCRIPTION
Adds an opt-in `stabilityCheck` option to `connect` and warns in development when `mapStateToProps` returns a different result for identical inputs.

Verification:
- `node_modules\.bin\vitest.cmd --run test/components/connect.spec.tsx`
- `node_modules\.bin\tsc.cmd --noEmit -p tsconfig.test.json`
