### PR TITLE
feat!: switch to native `NoInfer` utility type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['22.x']
+        node: ['24.x']
 
     steps:
       - name: Checkout code
@@ -54,8 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22.x']
-        ts: ['5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8']
+        node: ['24.x']
+        ts: ['5.5', '5.6', '5.7', '5.8']
         react:
           [
             {
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22.x']
+        node: ['24.x']
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22.x']
+        node: ['24.x']
         example:
           [
             'cra4',
@@ -178,7 +178,7 @@ jobs:
       - name: Clone RTK repo (pinned to known-good commit)
         run: |
           git init ./redux-toolkit
-          git -C ./redux-toolkit fetch --depth 1 https://github.com/reduxjs/redux-toolkit.git 576a02f8056fbee2dcaddb4d2e4d2da3b7937c58
+          git -C ./redux-toolkit fetch --depth 1 https://github.com/reduxjs/redux-toolkit.git 7c49510ff5dc6aad7cda24a59ec6c38a1af053be
           git -C ./redux-toolkit checkout FETCH_HEAD
 
       - name: Cache example deps
@@ -236,7 +236,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22.x']
+        node: ['24.x']
         example: ['rr-rsc-context']
     defaults:
       run:
@@ -283,7 +283,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['22.x']
+        node: ['24.x']
         react:
           [
             {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Clone RTK repo (pinned to known-good commit)
         run: |
           git init ./redux-toolkit
-          git -C ./redux-toolkit fetch --depth 1 https://github.com/reduxjs/redux-toolkit.git 7c49510ff5dc6aad7cda24a59ec6c38a1af053be
+          git -C ./redux-toolkit fetch --depth 1 https://github.com/reduxjs/redux-toolkit.git d974a4d252090eab9e029842042757bc43af8980
           git -C ./redux-toolkit checkout FETCH_HEAD
 
       - name: Cache example deps

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,9 +1,9 @@
 //import * as React from 'react'
-import { React } from '../utils/react'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 import type { ReactReduxContextValue } from '../components/Context'
 import { ReactReduxContext } from '../components/Context'
-import type { EqualityFn, NoInfer } from '../types'
+import type { EqualityFn } from '../types'
+import { React } from '../utils/react'
 import {
   createReduxContextHook,
   useReduxContext as useDefaultReduxContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,14 +5,10 @@ import type {
   FunctionComponent,
   JSX,
 } from 'react'
-
-import type { Action, UnknownAction, Dispatch } from 'redux'
-
-import type { NonReactStatics } from './utils/hoistStatics'
-
+import type { Action, Dispatch, UnknownAction } from 'redux'
 import type { ConnectProps } from './components/connect'
-
 import type { UseSelectorOptions } from './hooks/useSelector'
+import type { NonReactStatics } from './utils/hoistStatics'
 
 export type FixTypeLater = any
 
@@ -169,12 +165,10 @@ export type ResolveThunks<TDispatchProps> = TDispatchProps extends {
 export interface TypedUseSelectorHook<TState> {
   <TSelected>(
     selector: (state: TState) => TSelected,
-    equalityFn?: EqualityFn<NoInfer<TSelected>>,
+    equalityFn?: EqualityFn<TSelected>,
   ): TSelected
   <Selected = unknown>(
     selector: (state: TState) => Selected,
     options?: UseSelectorOptions<Selected>,
   ): Selected
 }
-
-export type NoInfer<T> = [T][T extends any ? 0 : never]


### PR DESCRIPTION
## Summary

- Switch to the native [**`NoInfer`**](https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype) utility type, introduced in [**TypeScript v5.4**](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4), which aligns with our minimum supported TypeScript version.
- Resolve #2313.