### PR TITLE
ci: publish preview packages via `pkg.pr.new`

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,0 @@
-{
-  "sandboxes": ["vanilla", "vanilla-ts"],
-  "node": "20",
-  "buildCommand": "build",
-  "packages": ["."]
-}

--- a/.github/workflows/release-commit.yml
+++ b/.github/workflows/release-commit.yml
@@ -1,0 +1,40 @@
+name: Release Commit
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release Commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          cache: 'yarn'
+          check-latest: true
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run: yarn run build
+
+      - name: Publish
+        id: publish
+        run: >
+          yarn dlx pkg-pr-new publish
+          .
+          --yarn --packageManager="npm,yarn,pnpm,bun" --commentWithDev


### PR DESCRIPTION
## Summary

[**CodeSandbox CI**](https://codesandbox.io/docs/learn/ci#what-is-codesandbox-ci) is deprecated and fully shuts down on **July 15, 2026**. We rely on it to publish installable preview builds of our packages for every commit/PR. Adopt [**`pkg.pr.new`**](https://github.com/stackblitz-labs/pkg.pr.new), a GitHub Actions-native equivalent, and retire CodeSandbox CI before the shutdown.

- Add a [**`pkg.pr.new`**](https://github.com/stackblitz-labs/pkg.pr.new) workflow that publishes preview builds per commit/PR, installable via **`npm install https://pkg.pr.new/react-redux@{PR}`**.
- Remove [**`.codesandbox/ci.json`**](.codesandbox/ci.json) and any remaining CodeSandbox CI references.
- Resolve #2322.