### PR TITLE
fix: honour explicit `dependsOnOwnProps=false` in getDependsOnOwnProps

### DIFF
--- a/src/connect/wrapMapToProps.ts
+++ b/src/connect/wrapMapToProps.ts
@@ -48,7 +48,7 @@ export function wrapMapToPropsConstant(
 // therefore not reporting its length accurately..
 // TODO Can this get pulled out so that we can subscribe directly to the store if we don't need ownProps?
 function getDependsOnOwnProps(mapToProps: MapToProps) {
-  return mapToProps.dependsOnOwnProps
+  return mapToProps.dependsOnOwnProps != null
     ? Boolean(mapToProps.dependsOnOwnProps)
     : mapToProps.length !== 1
 }

--- a/test/connect/wrapMapToProps.spec.ts
+++ b/test/connect/wrapMapToProps.spec.ts
@@ -1,0 +1,58 @@
+import { wrapMapToPropsFunc } from '@internal/connect/wrapMapToProps'
+import type { Dispatch } from 'redux'
+
+const fakeDispatch = (() => {}) as Dispatch
+const fakeOptions = { displayName: 'TestComponent' }
+
+describe('wrapMapToProps', () => {
+  describe('getDependsOnOwnProps', () => {
+    it('infers dependsOnOwnProps=true from a 2-arity function with no explicit flag', () => {
+      const mapToProps = (_state: any, _ownProps: any) => ({})
+      const proxy = wrapMapToPropsFunc(mapToProps, 'mapStateToProps')(
+        fakeDispatch,
+        fakeOptions,
+      )
+      proxy({}, undefined)
+      expect(proxy.dependsOnOwnProps).toBe(true)
+    })
+
+    it('infers dependsOnOwnProps=false from a 1-arity function with no explicit flag', () => {
+      const mapToProps = (_state: any) => ({})
+      const proxy = wrapMapToPropsFunc(mapToProps, 'mapStateToProps')(
+        fakeDispatch,
+        fakeOptions,
+      )
+      proxy({}, undefined)
+      expect(proxy.dependsOnOwnProps).toBe(false)
+    })
+
+    it('respects an explicit dependsOnOwnProps=false even when function arity is 2', () => {
+      // This is the bug: a 2-arg function with dependsOnOwnProps=false set
+      // should have the explicit flag honoured, not be overridden by the
+      // length heuristic.
+      const mapToProps = (_state: any, _ownProps: any) => ({})
+      ;(mapToProps as any).dependsOnOwnProps = false
+
+      const proxy = wrapMapToPropsFunc(mapToProps, 'mapStateToProps')(
+        fakeDispatch,
+        fakeOptions,
+      )
+      proxy({}, undefined)
+      // Before the fix: proxy.dependsOnOwnProps === true  (bug – length heuristic wins)
+      // After the fix:  proxy.dependsOnOwnProps === false (explicit flag is respected)
+      expect(proxy.dependsOnOwnProps).toBe(false)
+    })
+
+    it('respects an explicit dependsOnOwnProps=true even when function arity is 1', () => {
+      const mapToProps = (_state: any) => ({})
+      ;(mapToProps as any).dependsOnOwnProps = true
+
+      const proxy = wrapMapToPropsFunc(mapToProps, 'mapStateToProps')(
+        fakeDispatch,
+        fakeOptions,
+      )
+      proxy({}, undefined)
+      expect(proxy.dependsOnOwnProps).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`getDependsOnOwnProps` in `src/connect/wrapMapToProps.ts` uses a truthy check to decide whether the caller has explicitly set the `dependsOnOwnProps` flag:

```ts
// before
function getDependsOnOwnProps(mapToProps: MapToProps) {
  return mapToProps.dependsOnOwnProps
    ? Boolean(mapToProps.dependsOnOwnProps)
    : mapToProps.length !== 1
}
```

A truthy check treats `false` the same as `undefined`, so an **explicitly-set `dependsOnOwnProps = false`** falls through to the length heuristic and is silently overridden.

A concrete case: a `mapStateToProps` function with 2 parameters but `.dependsOnOwnProps = false` set (to opt out of ownProps-triggered re-renders) ends up with `dependsOnOwnProps = true` after the proxy initialises, causing the component to re-run `mapStateToProps` on every parent prop change even though the author explicitly disabled that.

## Fix

Replace the truthy check with a `!= null` check so that both `false` and `true` are treated as intentional signals, while `undefined`/`null` still falls back to the arity heuristic:

```ts
// after
function getDependsOnOwnProps(mapToProps: MapToProps) {
  return mapToProps.dependsOnOwnProps != null
    ? Boolean(mapToProps.dependsOnOwnProps)
    : mapToProps.length !== 1
}
```

## Tests

Four unit tests added in `test/connect/wrapMapToProps.spec.ts`:
- arity-2 with no explicit flag → inferred `true`
- arity-1 with no explicit flag → inferred `false`
- arity-2 with **explicit `false`** → **respects `false`** (was broken before this fix)
- arity-1 with explicit `true`  → respects `true`

All 189 existing tests continue to pass unchanged.

> AI-assisted contribution.