### PR TITLE
fix(isPlainObject): reject objects with a non-Object.prototype null-proto root

### DIFF
--- a/src/utils/isPlainObject.ts
+++ b/src/utils/isPlainObject.ts
@@ -13,5 +13,8 @@ export default function isPlainObject(obj: unknown) {
     baseProto = Object.getPrototypeOf(baseProto)
   }
 
-  return proto === baseProto
+  return (
+    proto === baseProto &&
+    typeof (baseProto as any).hasOwnProperty === 'function'
+  )
 }

--- a/test/utils/isPlainObject.spec.ts
+++ b/test/utils/isPlainObject.spec.ts
@@ -16,4 +16,10 @@ describe('isPlainObject', () => {
     expect(isPlainObject({ x: 1, y: 2 })).toBe(true)
     expect(isPlainObject(Object.create(null))).toBe(true)
   })
+  it('returns false for an object whose prototype is a non-Object.prototype null-proto object', () => {
+    // Object.create(null) creates a null-proto object that is NOT Object.prototype.
+    // Object.create(Object.create(null)) therefore has a prototype that is a root
+    // but not Object.prototype — it should NOT be considered plain.
+    expect(isPlainObject(Object.create(Object.create(null)))).toBe(false)
+  })
 })


### PR DESCRIPTION
## Problem

`isPlainObject` walks the prototype chain to find the `baseProto` — the first prototype whose own prototype is `null` — and then checks `proto === baseProto` (direct prototype IS the chain root).

This is correct for all documented cases, but produces a **false positive** for `Object.create(Object.create(null))`:

```ts
const nullObj = Object.create(null) // a null-proto object that is NOT Object.prototype
const obj = Object.create(nullObj)

// Before this fix:
isPlainObject(obj) // → true  ← wrong
```

Why: `nullObj` itself has no prototype, so it IS the chain root. `proto === baseProto` is satisfied even though `nullObj` is not `Object.prototype`.

## Root cause

The algorithm cannot distinguish between:
- `Object.prototype` (the real plain-object root) from any realm
- an arbitrary null-proto object that happens to be the chain root

## Fix

`Object.prototype` (from any realm) always has `hasOwnProperty` as an **own** function. A raw `Object.create(null)` object has no properties at all, so `typeof baseProto.hasOwnProperty === 'undefined'`.

Adding this guard to the return condition closes the false positive:

```ts
// after
return (
  proto === baseProto &&
  typeof (baseProto as any).hasOwnProperty === 'function'
)
```

## Verification

All 186 existing tests pass. A new test case covers the fixed scenario:

```ts
expect(isPlainObject(Object.create(Object.create(null)))).toBe(false)
```

Cross-realm objects (`vm.runInNewContext`) continue to return `true` because
each realm's `Object.prototype` always carries its own `hasOwnProperty` function.

> AI-assisted contribution.