### PR TITLE
ci: fix `pkg-pr-new` usage

### DIFF
--- a/.github/workflows/release-commit.yml
+++ b/.github/workflows/release-commit.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - run: corepack enable
 
@@ -35,6 +35,6 @@ jobs:
       - name: Publish
         id: publish
         run: >
-          yarn dlx pkg-pr-new publish
+          yarn run --binaries-only --top-level pkg-pr-new publish
           .
-          --yarn --packageManager="npm,yarn,pnpm,bun" --commentWithDev
+          --yarn --packageManager="npm,yarn,pnpm,bun" --commentWithDev --commentWithSha

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react": "^7.34.2",
     "jsdom": "^25.0.1",
+    "pkg-pr-new": "^0.0.75",
     "prettier": "^3.3.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,6 +4982,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg-pr-new@npm:^0.0.75":
+  version: 0.0.75
+  resolution: "pkg-pr-new@npm:0.0.75"
+  bin:
+    pkg-pr-new: bin/cli.js
+  checksum: 10/5160a67a955a50a5842cc43a5143e16f15e48bd5beaf6368ee4f3c532fd79e8ba703ffffd9479945b7ed52f65ce11990e2e24c96b6efd7dd30a326236721bd90
+  languageName: node
+  linkType: hard
+
 "pkg-types@npm:^1.3.0":
   version: 1.3.1
   resolution: "pkg-types@npm:1.3.1"
@@ -5168,6 +5177,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.1.3"
     eslint-plugin-react: "npm:^7.34.2"
     jsdom: "npm:^25.0.1"
+    pkg-pr-new: "npm:^0.0.75"
     prettier: "npm:^3.3.3"
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"


### PR DESCRIPTION
## Summary

- Add [`pkg-pr-new`](https://github.com/stackblitz-labs/pkg.pr.new) as a local dev dependency, as recommended in its documentation
- Run [`pkg-pr-new`](https://github.com/stackblitz-labs/pkg.pr.new) via `yarn run --binaries-only --top-level` instead of `yarn dlx`
- Add the `--commentWithSha` flag
- Bump `actions/checkout` from `v6.0.3` to `v7.0.0`