### PR TITLE
fix(`useSelector`): wrap `equalityFnOrOptions` in `NoInfer` to preserve `Selected` inference

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pretest": "yarn lint",
     "test": "vitest --run --typecheck",
     "test:watch": "vitest --watch",
-    "type-tests": "tsc --noEmit -p tsconfig.test.json",
+    "type-tests": "tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p tsconfig.test.nonStrictFunctionTypes.json",
     "coverage": "codecov"
   },
   "peerDependencies": {

--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -41,7 +41,7 @@ import { ReactReduxContext } from './Context'
 
 // Define some constant arrays just to avoid re-creating these
 const EMPTY_ARRAY: [unknown, number] = [null, 0]
-const NO_SUBSCRIPTION_ARRAY = [null, null]
+const NO_SUBSCRIPTION_ARRAY: [null, null] = [null, null]
 
 // Attempts to stringify whatever not-really-a-component value we were given
 // for logging in an error message

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -90,7 +90,9 @@ export interface UseSelector<StateType = unknown> {
    */
   <TState extends StateType = StateType, Selected = unknown>(
     selector: (state: TState) => Selected,
-    equalityFnOrOptions?: EqualityFn<Selected> | UseSelectorOptions<Selected>,
+    equalityFnOrOptions?:
+      | EqualityFn<NoInfer<Selected>>
+      | UseSelectorOptions<NoInfer<Selected>>,
   ): Selected
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,10 +165,10 @@ export type ResolveThunks<TDispatchProps> = TDispatchProps extends {
 export interface TypedUseSelectorHook<TState> {
   <TSelected>(
     selector: (state: TState) => TSelected,
-    equalityFn?: EqualityFn<TSelected>,
+    equalityFn?: EqualityFn<NoInfer<TSelected>>,
   ): TSelected
   <Selected = unknown>(
     selector: (state: TState) => Selected,
-    options?: UseSelectorOptions<Selected>,
+    options?: UseSelectorOptions<NoInfer<Selected>>,
   ): Selected
 }

--- a/test/typetests/hooks.nonStrictFunctionTypes.test-d.tsx
+++ b/test/typetests/hooks.nonStrictFunctionTypes.test-d.tsx
@@ -1,0 +1,69 @@
+// In addition to the regular strict compilation of `tsconfig.test.json`,
+// this file is compiled by `tsconfig.test.nonStrictFunctionTypes.json` with
+// `strictFunctionTypes` disabled. In that configuration, inference for
+// `Selected` used to be poisoned by the second argument of `useSelector`:
+// passing `shallowEqual` (typed `(objA: any, objB: any) => boolean`) made
+// `Selected` collapse to `any`, and a generic equality function made it
+// collapse to `unknown`.
+// See https://github.com/reduxjs/react-redux/issues/2186
+import { shallowEqual, useSelector } from 'react-redux'
+import type { TypedUseSelectorHook } from 'react-redux'
+
+describe('type tests', () => {
+  interface Editor {
+    id: string
+    active: boolean
+  }
+
+  interface AppState {
+    editors: Editor[]
+  }
+
+  const selectEditors = (state: AppState) => state.editors
+
+  const useAppSelector = useSelector.withTypes<AppState>()
+
+  test('shallowEqual does not make useSelector lose the selected type', () => {
+    const editors = useSelector(selectEditors, shallowEqual)
+
+    expectTypeOf(editors).toEqualTypeOf<Editor[]>()
+  })
+
+  test('shallowEqual does not make a pre-typed useSelector lose the selected type', () => {
+    const editors = useAppSelector(selectEditors, shallowEqual)
+
+    expectTypeOf(editors).toEqualTypeOf<Editor[]>()
+
+    const editorsInline = useAppSelector((state) => state.editors, shallowEqual)
+
+    expectTypeOf(editorsInline).toEqualTypeOf<Editor[]>()
+  })
+
+  test('shallowEqual as the equalityFn option does not lose the selected type', () => {
+    const editors = useAppSelector(selectEditors, { equalityFn: shallowEqual })
+
+    expectTypeOf(editors).toEqualTypeOf<Editor[]>()
+  })
+
+  test('a generic equality function does not make useSelector lose the selected type', () => {
+    const genericEqual = shallowEqual as <T>(a: T, b: T) => boolean
+
+    const editors = useAppSelector(selectEditors, genericEqual)
+
+    expectTypeOf(editors).toEqualTypeOf<Editor[]>()
+  })
+
+  test('shallowEqual does not make TypedUseSelectorHook lose the selected type', () => {
+    const useTypedSelector: TypedUseSelectorHook<AppState> = useSelector
+
+    const editors = useTypedSelector(selectEditors, shallowEqual)
+
+    expectTypeOf(editors).toEqualTypeOf<Editor[]>()
+
+    const editorsViaOptions = useTypedSelector(selectEditors, {
+      equalityFn: shallowEqual,
+    })
+
+    expectTypeOf(editorsViaOptions).toEqualTypeOf<Editor[]>()
+  })
+})

--- a/tsconfig.test.nonStrictFunctionTypes.json
+++ b/tsconfig.test.nonStrictFunctionTypes.json
@@ -1,0 +1,10 @@
+{
+  // Compiles the marked type tests with `strictFunctionTypes` disabled, the
+  // configuration that reproduced the `useSelector` + `shallowEqual` inference
+  // regression: https://github.com/reduxjs/react-redux/issues/2186
+  "extends": "./tsconfig.test.json",
+  "compilerOptions": {
+    "strictFunctionTypes": false
+  },
+  "include": ["test/typetests/hooks.nonStrictFunctionTypes.test-d.tsx"]
+}


### PR DESCRIPTION
## Problem

Passing `shallowEqual` (or any concretely-typed / generic equality function) as the second argument of `useSelector` / a `withTypes`'d `useSelector` made the selected value collapse to `any` (or `unknown` for a generic equality function such as the `shallowEqual as <T>(a: T, b: T) => boolean` workaround, reported broken since 9.2.0).

## Root cause

The public `UseSelector` call signature declared

```ts
equalityFnOrOptions?: EqualityFn<Selected> | UseSelectorOptions<Selected>
```

without `NoInfer`, while the implementation signature already wraps `Selected` in `NoInfer`. So `Selected` could also be inferred from the equality function's parameters. `shallowEqual` is typed `(objA: any, objB: any) => boolean`, contributing an `any` inference candidate.

**Why the existing type test never caught it:** the regression only manifests with `strictFunctionTypes` disabled (common in older codebases — the reporter migrated from react-redux 7, and it also explains why their "clean project" sandbox didn't reproduce). With `strictFunctionTypes` on, the equality-fn parameter candidates are contravariant and lose to the selector's covariant return-type candidate; with it off, they become regular covariant candidates and `any` absorbs the union (`unknown` for generic equality fns). I verified the strict suite cannot fail on this with any repro form across TS 4.7–5.8.

## Fix

Applies exactly the diff @EskiMojo14 suggested in the issue thread: the public overload now uses `EqualityFn<NoInfer<Selected>> | UseSelectorOptions<NoInfer<Selected>>`, matching the implementation signature, so `Selected` is only ever inferred from the selector.

`TypedUseSelectorHook` (which the issue reporter was using as their workaround) has the same unprotected signatures in both of its overloads and is fixed the same way.

## Tests

- New `test/typetests/hooks.nonStrictFunctionTypes.test-d.tsx` covering the issue's repro forms (plain `useSelector` + typed selector, `withTypes`'d hook with declared and inline selectors, `{ equalityFn: shallowEqual }` options form, a generic equality function, and `TypedUseSelectorHook` with both the equality-fn and options-object overloads).
- New `tsconfig.test.nonStrictFunctionTypes.json` compiles that file with `strictFunctionTypes: false`; `yarn type-tests` now runs both tsc passes, so this is exercised across the CI TypeScript matrix. **Without the fix this pass fails with 7 errors** (collapse-to-`any` / collapse-to-`unknown` at every new assertion); with the fix it is green. The file is also included in the regular strict pass and vitest typecheck.
- `src/components/connect.tsx`: `NO_SUBSCRIPTION_ARRAY` is now explicitly typed as the `[null, null]` tuple (same pattern as `EMPTY_ARRAY` on the line above, no runtime change). Without it, the non-strict pass hits a pre-existing `strictFunctionTypes: false`-only error in `connect` (the `useMemo` result loses its discriminated tuple-union shape, so `notifyNestedSubs` fails to narrow from `VoidFunc | null`), and `connect.tsx` is pulled into any type-test program via a type-only import in `types.ts`.
- Full suite green: `yarn vitest --run --typecheck` (190 tests, no type errors), `yarn lint`, `yarn build` (emitted `dist/react-redux.d.ts` contains the `NoInfer` wrapper), and `yarn type-tests` on TS 5.5/5.6/5.7/5.8.

Fixes #2186
