### PR TITLE
fix(`connect`): split `mapStateToProps`/`mapDispatchToProps` unions into ordered overloads (#2244)

### DIFF
--- a/src/components/connect.tsx
+++ b/src/components/connect.tsx
@@ -15,10 +15,14 @@ import type {
 } from '../types'
 
 import type {
+  MapStateToProps,
+  MapStateToPropsFactory,
   MapStateToPropsParam,
+  MapDispatchToProps,
+  MapDispatchToPropsFactory,
+  MapDispatchToPropsFunction,
   MapDispatchToPropsParam,
   MergeProps,
-  MapDispatchToPropsNonObject,
   SelectorFactoryOptions,
 } from '../connect/selectorFactory'
 import defaultSelectorFactory from '../connect/selectorFactory'
@@ -279,47 +283,128 @@ export interface ConnectOptions<
  */
 export interface Connect<DefaultState = unknown> {
   // tslint:disable:no-unnecessary-generics
+  //
+  // NOTE: the `mapStateToProps` and `mapDispatchToProps` parameters are
+  // intentionally split into separate "factory" and "plain" overloads instead of
+  // accepting the `MapStateToPropsParam` / `MapDispatchToProps{Param,NonObject}`
+  // unions directly. A factory (e.g. `() => (state) => props`) is structurally
+  // assignable to its plain counterpart, so when both forms live in a single
+  // union the compiler has to pick a "first" inference candidate - and the old
+  // and new (native, TS 7 / `tsgo`) compilers order union members differently,
+  // inferring `TStateProps` / `TDispatchProps` incorrectly on one of them.
+  // Listing the factory overload first makes the resolution order explicit and
+  // compiler-independent. The `mergeProps` overloads keep the unions on purpose
+  // (see the note on those overloads below).
+  // See https://github.com/reduxjs/react-redux/issues/2244
   (): InferableComponentEnhancer<DispatchProp>
+
+  /** mapState only (as a factory) */
+  <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+  ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>
 
   /** mapState only */
   <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
   ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>
+
+  /** mapDispatch only (as a factory) */
+  <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
 
   /** mapDispatch only (as a function) */
   <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
     mapStateToProps: null | undefined,
-    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
 
   /** mapDispatch only (as an object) */
   <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
     mapStateToProps: null | undefined,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToProps<TDispatchProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<
     ResolveThunks<TDispatchProps>,
     TOwnProps
   >
 
-  /** mapState and mapDispatch (as a function)*/
+  /** mapState (as a factory) and mapDispatch (as a factory) */
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<
     TStateProps & TDispatchProps,
     TOwnProps
   >
 
-  /** mapState and mapDispatch (nullish) */
+  /** mapState (as a factory) and mapDispatch (as a function) */
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
+
+  /** mapState and mapDispatch (as a factory) */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
+
+  /** mapState and mapDispatch (as a function)*/
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
+
+  /** mapState (as a factory) and mapDispatch (nullish) */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
     mapDispatchToProps: null | undefined,
   ): InferableComponentEnhancerWithProps<TStateProps, TOwnProps>
 
+  /** mapState and mapDispatch (nullish) */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: null | undefined,
+  ): InferableComponentEnhancerWithProps<TStateProps, TOwnProps>
+
+  /** mapState (as a factory) and mapDispatch (as an object) */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToProps<TDispatchProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & ResolveThunks<TDispatchProps>,
+    TOwnProps
+  >
+
   /** mapState and mapDispatch (as an object) */
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: MapDispatchToProps<TDispatchProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<
     TStateProps & ResolveThunks<TDispatchProps>,
     TOwnProps
@@ -331,6 +416,10 @@ export interface Connect<DefaultState = unknown> {
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<undefined, DispatchProp, TOwnProps, TMergedProps>,
   ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
+
+  // `mergeProps` overloads keep the union parameters (see the note on the final
+  // `mergeProps` overload below) - splitting off a factory overload would
+  // collapse the inferred props to `{}`.
 
   /** mapState and mergeProps */
   <
@@ -352,18 +441,37 @@ export interface Connect<DefaultState = unknown> {
     mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
   ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>
 
-  /** mapState and options */
+  /** mapState (as a factory) and options */
   <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
     options: ConnectOptions<State, TStateProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<DispatchProp & TStateProps, TOwnProps>
 
+  /** mapState and options */
+  <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: null | undefined,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<DispatchProp & TStateProps, TOwnProps>
+
+  /** mapDispatch (as a factory) and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<{}, TStateProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
+
   /** mapDispatch (as a function) and options */
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
     mapStateToProps: null | undefined,
-    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: ConnectOptions<{}, TStateProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>
@@ -371,7 +479,7 @@ export interface Connect<DefaultState = unknown> {
   /** mapDispatch (as an object) and options*/
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
     mapStateToProps: null | undefined,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToProps<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: ConnectOptions<{}, TStateProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<
@@ -379,10 +487,10 @@ export interface Connect<DefaultState = unknown> {
     TOwnProps
   >
 
-  /** mapState,  mapDispatch (as a function), and options */
+  /** mapState (as a factory), mapDispatch (as a factory), and options */
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-    mapDispatchToProps: MapDispatchToPropsNonObject<TDispatchProps, TOwnProps>,
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: ConnectOptions<State, TStateProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<
@@ -390,16 +498,78 @@ export interface Connect<DefaultState = unknown> {
     TOwnProps
   >
 
-  /** mapState,  mapDispatch (as an object), and options */
+  /** mapState (as a factory), mapDispatch (as a function), and options */
   <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
+
+  /** mapState, mapDispatch (as a factory), and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
+
+  /** mapState,  mapDispatch (as a function), and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: MapDispatchToPropsFunction<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & TDispatchProps,
+    TOwnProps
+  >
+
+  /** mapState (as a factory), mapDispatch (as an object), and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps: MapStateToPropsFactory<TStateProps, TOwnProps, State>,
+    mapDispatchToProps: MapDispatchToProps<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: ConnectOptions<State, TStateProps, TOwnProps>,
   ): InferableComponentEnhancerWithProps<
     TStateProps & ResolveThunks<TDispatchProps>,
     TOwnProps
   >
+
+  /** mapState,  mapDispatch (as an object), and options */
+  <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = DefaultState>(
+    mapStateToProps:
+      | MapStateToProps<TStateProps, TOwnProps, State>
+      | null
+      | undefined,
+    mapDispatchToProps: MapDispatchToProps<TDispatchProps, TOwnProps>,
+    mergeProps: null | undefined,
+    options: ConnectOptions<State, TStateProps, TOwnProps>,
+  ): InferableComponentEnhancerWithProps<
+    TStateProps & ResolveThunks<TDispatchProps>,
+    TOwnProps
+  >
+
+  // NOTE: the `mergeProps` overloads keep the union parameters rather than the
+  // factory/plain split used above. `mergeProps` receives `stateProps` and
+  // `dispatchProps` as contextually-typed (non-inferring) parameters, so
+  // `TStateProps` / `TDispatchProps` can only be inferred from `mapStateToProps`
+  // / `mapDispatchToProps`. With a dedicated factory overload listed first a
+  // plain map function gets captured by it and the inferred props collapse to
+  // `{}`. The union keeps both forms as inference candidates in a single
+  // overload, which is the original (and correct) behavior for these signatures.
 
   /** mapState, mapDispatch, mergeProps, and options */
   <

--- a/test/typetests/connect-union-ordering.test-d.tsx
+++ b/test/typetests/connect-union-ordering.test-d.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react'
+import { connect } from 'react-redux'
+
+// Type tests for https://github.com/reduxjs/react-redux/issues/2244
+//
+// `connect`'s `mapStateToProps` / `mapDispatchToProps` parameters used to be
+// typed as unions (e.g. `MapStateToPropsFactory | MapStateToProps | null |
+// undefined`). A factory (`() => (state) => props`) is structurally assignable
+// to its plain counterpart, so with both forms in a single union the compiler
+// has to choose a "first" inference candidate for `TStateProps` /
+// `TDispatchProps` - and the old and new (native, TS 7 / `tsgo`) compilers order
+// union members differently, so the props were inferred incorrectly on one of
+// them (collapsing the connected component's props to `{}`).
+//
+// The overloads are now split so the factory form is listed first as an
+// explicit overload, making resolution deterministic and compiler-independent.
+// These cases mirror the repro from https://github.com/lukeapage/ts-repro-1 and
+// must hold regardless of the order of the union members.
+
+type Props = Readonly<{
+  stringProp: string
+  defaultBooleanProp: boolean
+}>
+
+class ExampleComponent extends React.PureComponent<Props> {
+  static defaultProps = {
+    defaultBooleanProp: false,
+  }
+
+  render() {
+    const { defaultBooleanProp, stringProp } = this.props
+    return defaultBooleanProp && stringProp
+  }
+}
+
+function testPlainMapStateToProps() {
+  interface StateProps {
+    stringProp: string
+  }
+
+  interface OwnProps {
+    defaultBooleanProp?: boolean
+  }
+
+  const mapStateToProps = (state: any, props: OwnProps): StateProps => ({
+    stringProp: 'a',
+  })
+
+  const Connected = connect(mapStateToProps)(ExampleComponent)
+
+  // `stringProp` comes from the store, so it must NOT be a required own prop.
+  const ok = <Connected />
+  const okWithOwn = <Connected defaultBooleanProp />
+
+  // a factory whose inner selector returns the wrong shape must still be
+  // detected at the `connect` call (no inner return-type annotation)
+  const badFactory = () => (state: any, props: OwnProps) => ({
+    stringProp: 1,
+  })
+
+  // @ts-expect-error `stringProp` is a `number`, but the component wants a `string`
+  const ConnectedBad = connect(badFactory)(ExampleComponent)
+}
+
+function testFactoryMapStateToProps() {
+  interface StateProps {
+    stringProp: string
+  }
+
+  interface OwnProps {
+    defaultBooleanProp?: boolean
+  }
+
+  const mapStateToPropsFactory =
+    () =>
+    // @ts-expect-error the inner selector's annotated return type is violated
+    (state: any, props: OwnProps): StateProps => ({ stringProp: 1 })
+
+  // the factory is recognized as a factory: `TStateProps` is `StateProps`, so
+  // `stringProp` is provided by the store and is not a required own prop
+  const Connected = connect(mapStateToPropsFactory)(ExampleComponent)
+  const ok = <Connected />
+}
+
+function testFactoryMapStateToPropsExtraProp() {
+  interface StateProps {
+    stringProp: string
+  }
+
+  interface OwnProps {
+    defaultBooleanProp?: boolean
+  }
+
+  const mapStateToPropsFactory =
+    () =>
+    (state: any, props: OwnProps): StateProps => ({
+      // @ts-expect-error `fakeProp` is not part of `StateProps`
+      fakeProp: 1,
+      stringProp: 'a',
+    })
+
+  const Connected = connect(mapStateToPropsFactory)(ExampleComponent)
+  const ok = <Connected />
+}
+
+interface DispatchProps {
+  onClick: () => void
+}
+
+interface DispatchOwnProps {
+  id: string
+}
+
+class ClickableComponent extends React.PureComponent<
+  DispatchProps & DispatchOwnProps
+> {
+  render() {
+    return null
+  }
+}
+
+function testMapDispatchToPropsForms() {
+  // function form
+  const mapDispatchToProps = (dispatch: any): DispatchProps => ({
+    onClick: () => dispatch({ type: 'CLICK' }),
+  })
+  const ConnectedFn = connect(null, mapDispatchToProps)(ClickableComponent)
+  const okFn = <ConnectedFn id="a" />
+  // @ts-expect-error `id` is a required own prop; `onClick` is injected
+  const badFn = <ConnectedFn />
+
+  // factory form - recognized as a factory, so `onClick` is injected
+  const mapDispatchToPropsFactory =
+    () =>
+    (dispatch: any): DispatchProps => ({
+      onClick: () => dispatch({ type: 'CLICK' }),
+    })
+  const ConnectedFactory = connect(
+    null,
+    mapDispatchToPropsFactory,
+  )(ClickableComponent)
+  const okFactory = <ConnectedFactory id="a" />
+  // @ts-expect-error `id` is a required own prop; `onClick` is injected
+  const badFactory = <ConnectedFactory />
+
+  // object form - thunk action creators are resolved and injected
+  const mapDispatchObject = {
+    onClick: () => ({ type: 'CLICK' as const }),
+  }
+  const ConnectedObj = connect(null, mapDispatchObject)(ClickableComponent)
+  const okObj = <ConnectedObj id="a" />
+}
+
+function testFactoryMapStateWithFactoryMapDispatch() {
+  interface StateProps {
+    stringProp: string
+  }
+
+  interface OwnProps {
+    defaultBooleanProp?: boolean
+  }
+
+  class Combined extends React.PureComponent<
+    StateProps & DispatchProps & OwnProps
+  > {
+    render() {
+      return null
+    }
+  }
+
+  const mapStateToPropsFactory =
+    () =>
+    (state: any, props: OwnProps): StateProps => ({ stringProp: 'a' })
+
+  const mapDispatchToPropsFactory =
+    () =>
+    (dispatch: any): DispatchProps => ({
+      onClick: () => dispatch({ type: 'CLICK' }),
+    })
+
+  // covers the split "mapState (factory) + mapDispatch (factory)" overload:
+  // both `stringProp` and `onClick` are injected, so neither is a required own prop
+  const Connected = connect(
+    mapStateToPropsFactory,
+    mapDispatchToPropsFactory,
+  )(Combined)
+  const ok = <Connected />
+
+  // @ts-expect-error `unknownProp` is not an own prop of the connected component
+  const bad = <Connected unknownProp />
+}


### PR DESCRIPTION
Fixes #2244.

`connect`'s `mapStateToProps` and `mapDispatchToProps` are typed as unions that include both a "factory" form (`() => (state) => props`) and a plain form. A factory is structurally assignable to its plain counterpart, so the compiler has to pick a "first" candidate to infer `TStateProps` / `TDispatchProps` from — and `tsc` and the new native compiler (`tsgo` / TS 7) order union members differently. One of them ends up inferring the wrong candidate and the connected component's props collapse to `{}` (a required prop shows up as "missing" at the call site).

As Anders suggested in the upstream analysis (microsoft/typescript-go#977), the robust fix is to break the union into separate overloads listed in order of preference rather than relying on union ordering. So I've split the affected overloads with the factory form listed first, followed by the plain form. A plain object-returning function isn't assignable to the factory signature, so a factory matches the first overload and everything else falls through — deterministically, and independent of the compiler.

A couple of notes on scope:

- The object form of `mapDispatchToProps` doesn't get its own factory overload: factories and dispatch functions are already matched by the function-form overloads that precede it, so the object overloads only need the plain (`MapDispatchToProps`) parameter. This keeps the overload count from exploding.
- The `mergeProps` overloads deliberately keep the union parameters. There `mergeProps` receives `stateProps` / `dispatchProps` as contextually-typed (non-inferring) parameters, so those types can only come from the map functions — and a leading factory overload would swallow a plain map function and collapse the inferred props to `{}`. Keeping both forms as candidates in a single overload preserves the original behavior. It's documented inline.

Types only, no runtime changes.

I added type tests covering the repro cases from the issue (plain/factory `mapStateToProps`, the function/factory/object forms of `mapDispatchToProps`, a factory + factory combination, and the wrong-return-type cases). They pass under both `tsc` and the native compiler, and — this is the important part — they stay green even if the union members are reordered, which is the actual failure mode here: reordering the unions on plain `tsc` reproduces the exact errors from the report before this change, and no longer does after it.

One caveat worth mentioning: current `tsgo` dev builds may already infer these cases correctly, but the union ordering is still load-bearing and fragile, and the compiler-side issue was closed as "not planned" — so this makes the types stable regardless of compiler or union order.
