### PR TITLE
fix(useSelector): add `NoInfer` to equality fn in `UseSelector` type (#2186)

### DIFF
--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -90,7 +90,9 @@ export interface UseSelector<StateType = unknown> {
    */
   <TState extends StateType = StateType, Selected = unknown>(
     selector: (state: TState) => Selected,
-    equalityFnOrOptions?: EqualityFn<Selected> | UseSelectorOptions<Selected>,
+    equalityFnOrOptions?:
+      | EqualityFn<NoInfer<Selected>>
+      | UseSelectorOptions<NoInfer<Selected>>,
   ): Selected
 
   /**

--- a/test/typetests/hooks.test-d.tsx
+++ b/test/typetests/hooks.test-d.tsx
@@ -100,6 +100,29 @@ describe('type tests', () => {
     const selected2 = useAppSelector((state) => state.stateProp, shallowEqual)
 
     expectTypeOf(selected2).toBeString()
+
+    // https://github.com/reduxjs/react-redux/issues/2186
+    // The equality function must not be an inference site for `Selected`,
+    // otherwise `shallowEqual`'s `any` parameters widen the result to `any`.
+
+    // Selector declared separately (rather than inline) with `withTypes`.
+    const selectStateProp = (state: TestState) => state.stateProp
+
+    const selected3 = useAppSelector(selectStateProp, shallowEqual)
+
+    expectTypeOf(selected3).toBeString()
+
+    // Selector declared separately with plain `useSelector`.
+    const selected4 = useSelector(selectStateProp, shallowEqual)
+
+    expectTypeOf(selected4).toBeString()
+
+    // `shallowEqual` passed via the options object.
+    const selected5 = useAppSelector((state) => state.stateProp, {
+      equalityFn: shallowEqual,
+    })
+
+    expectTypeOf(selected5).toBeString()
   })
 
   test('useDispatch', () => {


### PR DESCRIPTION
Fixes #2186.

When you pass `shallowEqual` as the second argument to `useSelector` (or to a
hook made with `useSelector.withTypes<State>()`), TypeScript was treating the
equality function as an inference site for the selected value. `shallowEqual`
is typed with `any` parameters, so that could collapse the result down to `any`
instead of the selector's actual return type.

The implementation inside `createSelectorHook` already wraps this argument in
`NoInfer` — the public `UseSelector` interface just never got the same
treatment. So this just brings the two in line:

```diff
   <TState extends StateType = StateType, Selected = unknown>(
     selector: (state: TState) => Selected,
-    equalityFnOrOptions?: EqualityFn<Selected> | UseSelectorOptions<Selected>,
+    equalityFnOrOptions?:
+      | EqualityFn<NoInfer<Selected>>
+      | UseSelectorOptions<NoInfer<Selected>>,
   ): Selected
```

One heads-up: on `master` with the currently supported TS versions I couldn't
actually reproduce the `any` result anymore — the existing `shallowEqual` test
passes, and the new ones pass with or without this change. So really this is
(a) keeping the public type consistent with the implementation, and (b) a
safety net for older/other TS setups where the equality arg can still leak into
inference. If you'd rather just close the issue with the added tests and skip
the type change, I'm happy to drop it.

I also added type tests for the cases from the issue that weren't covered
before: a selector declared as a separate variable (not inline), the same
through plain `useSelector`, and passing `shallowEqual` via the options object.

Type-only change, nothing runtime.