### PR TITLE
fix(`Provider`): throw a clearer error when rendered in a React Server Component (#2082)

### DIFF
--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -57,6 +57,25 @@ export interface ProviderProps<
 function Provider<A extends Action<string> = UnknownAction, S = unknown>(
   providerProps: ProviderProps<A, S>,
 ) {
+  if (process.env.NODE_ENV !== 'production') {
+    // React Server Components do not provide the effect hooks that `<Provider>`
+    // relies on, so `useIsomorphicLayoutEffect` (which resolves to
+    // `useLayoutEffect`/`useEffect`) is `undefined` in that environment. Detect
+    // this before any hook runs and throw an actionable error, instead of the
+    // cryptic "X is not a function" that would otherwise surface.
+    if (typeof useIsomorphicLayoutEffect !== 'function') {
+      throw new Error(
+        'The React Redux `<Provider>` component requires React hooks that are ' +
+          'not available in a React Server Component. This usually means you are ' +
+          'rendering `<Provider>` in a Server Component. Add the `"use client"` ' +
+          'directive to the top of the file that renders `<Provider>` (or a ' +
+          'parent that ends up rendering it) so it is treated as a Client ' +
+          'Component. See https://react.dev/reference/rsc/use-client for more ' +
+          'information.',
+      )
+    }
+  }
+
   const { children, context, serverState, store } = providerProps
 
   const contextValue = React.useMemo(() => {

--- a/test/components/Provider-rsc.spec.tsx
+++ b/test/components/Provider-rsc.spec.tsx
@@ -1,0 +1,42 @@
+/*eslint-disable react/prop-types*/
+
+import * as rtl from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+
+// In a React Server Components environment, React does not expose the effect
+// hooks that `<Provider>` relies on, so `useIsomorphicLayoutEffect` (which
+// resolves to `useLayoutEffect`/`useEffect`) ends up `undefined`. Simulate that
+// here to assert `<Provider>` surfaces a clear, actionable error rather than a
+// cryptic "X is not a function".
+vi.mock('../../src/utils/useIsomorphicLayoutEffect', () => ({
+  useIsomorphicLayoutEffect: undefined,
+}))
+
+// This mock replaces an internal source module, which only exists as a separate
+// module in the `src` build. When the suite runs against the bundled build
+// artifact (`TEST_DIST`), `useIsomorphicLayoutEffect` is inlined into a single
+// file with no module boundary left to mock, so the RSC condition cannot be
+// simulated there. The guard itself is unchanged between builds, so exercising
+// it against `src` is sufficient.
+const describeSource = process.env.TEST_DIST ? describe.skip : describe
+
+describeSource('React', () => {
+  describe('Provider in a React Server Component environment', () => {
+    it('throws an actionable error when React effect hooks are unavailable', () => {
+      const store = createStore(() => ({}))
+
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(() =>
+        rtl.render(
+          <Provider store={store}>
+            <div />
+          </Provider>,
+        ),
+      ).toThrow(/React Server Component/)
+
+      spy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
Closes #2082.

If you render `<Provider>` in a Server Component you currently get a pretty useless error. In React's `react-server` build the effect hooks just don't exist (`useEffect`/`useLayoutEffect`/`useRef`/`useState` are all `undefined` — only `useMemo`, `use`, `useId` and friends survive), so `useIsomorphicLayoutEffect` ends up `undefined` and you hit `useIsomorphicLayoutEffect is not a function`. Adding `"use client"` doesn't really help either — as noted in the issue, `store`/`context` aren't serializable so you just trade it for a different confusing error.

So this does what the thread landed on: an explicit dev-only check at the top of `<Provider>`, before any hook runs, that throws a message actually telling you what's wrong and to add `"use client"`.

The `"react-server"` export condition already handles the normal Next.js case, but only when the bundler applies it to `react-redux` too. This is the fallback for the "and many others" setups where React resolves to its server build but we don't — and since every app renders `<Provider>`, that's a good enough place to catch it.

On testing (which came up in the thread): we don't need a real RSC environment. The whole thing hinges on `useIsomorphicLayoutEffect` being `undefined`, so the test just mocks it to `undefined` and checks `<Provider>` throws. Without the guard you'd get `... is not a function` instead, which doesn't match, so the test really is hitting the new branch.

Kept it scoped to `<Provider>` — the hooks would blow up in RSC too, but the Provider is the earliest thing everyone renders.

Changes:
- `src/components/Provider.tsx` — the guard (dev only, stripped in prod)
- `test/components/Provider-rsc.spec.tsx` — new test, separate file so the module mock doesn't leak into the other Provider tests
