### PR TITLE
Remove the `alternate-renderers` entry point

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
 
       # Note: We currently expect "FalseCJS" failures for Node16 + `moduleResolution: "node16",
       - name: Run are-the-types-wrong
-        run: yarn attw ./package.tgz --format table --ignore-rules false-cjs --exclude-entrypoints alternate-renderers
+        run: yarn attw ./package.tgz --format table --ignore-rules false-cjs
 
   test-published-artifact:
     name: Test Published Artifact ${{ matrix.example }}

--- a/package.json
+++ b/package.json
@@ -24,11 +24,6 @@
       "react-native": "./dist/react-redux.legacy-esm.js",
       "import": "./dist/react-redux.mjs",
       "default": "./dist/cjs/index.js"
-    },
-    "./alternate-renderers": {
-      "types": "./dist/react-redux.d.ts",
-      "import": "./dist/react-redux.mjs",
-      "default": "./dist/cjs/index.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Closes #2336

The `react-redux/alternate-renderers` build was originally there to give you a version that didn't pull in `unstable_batchedUpdates` from React DOM / React Native, for use in other renderers. Since we moved to `useSyncExternalStore` in v8 the main entry doesn't do any manual batching anymore, so this build doesn't buy anything — it was already re-exporting the exact same files as the main entry.

So I dropped it:

- removed the `"./alternate-renderers"` block from `exports` in `package.json`
- removed `--exclude-entrypoints alternate-renderers` from the attw check in CI, since there's nothing to exclude now

This is a breaking change for v10. If you were importing from `react-redux/alternate-renderers`, just import from `react-redux` instead:

```diff
- import { Provider } from 'react-redux/alternate-renderers'
+ import { Provider } from 'react-redux'
```

Nothing else in the repo references it, and the tsup build output is unchanged (that entry never produced its own files).