### PR TITLE
perf(signals): defer selector tracking off the mount render path

### DIFF
--- a/src/signals/useSignalSelector.ts
+++ b/src/signals/useSignalSelector.ts
@@ -288,10 +288,20 @@ const useSignalSelectorImpl = <S, R>(
       }
     })
 
-    // Initialize with current value. A selector that throws on mount
-    // surfaces here, during render — same as stock useSelector.
-    currentResult = selectorComputed.get()
-    if (pendingError !== null) {
+    // MOUNT OPT: seed the first-render value with a cheap UNTRACKED run of
+    // the selector against raw state, instead of the eager tracked
+    // `selectorComputed.get()`. Building the tracking proxy + registering
+    // path signals (the expensive part) is deferred to the first
+    // `engine.effect` run inside subscribe(), which React invokes in the
+    // commit phase — off the render-blocking path. The raw run yields the
+    // same value (`untrackResult` is a no-op on already-raw state), so the
+    // first-render snapshot is unchanged; the dependency graph is
+    // established lazily on subscribe. A selector that throws
+    // deterministically still throws here, during render (stock parity).
+    try {
+      currentResult = untrackResult(selectorRef.current(store.getState() as S))
+    } catch (e) {
+      pendingError = e
       throw pendingError
     }
 


### PR DESCRIPTION
Follow-up on `43d0049` — fixes the mount cost of `useSignalSelector`.

Seeds the first render with a cheap untracked selector run and defers the proxy/signal tracking to the first `subscribe()` effect (commit phase) instead of building it eagerly during render. Same value on first paint, same throw-on-mount behaviour, nothing touched in the registry/proxy/diff.

price-ticker mount: ~160ms → ~29ms (stock ~28ms). Dispatch/update numbers unchanged, all 413 signals tests pass.

To be clear about what it buys: faster first paint, not faster time-to-interactive — the tracking build still happens, it just moves off the render path. As a bonus, components that render but never commit (Offscreen, virtualization) stop paying for tracking at all.

Caveat worth flagging: passive effects aren't time-sliced the way render is under concurrent mode, so for a transition-driven mount this could move sliceable work into a non-sliceable spot after paint. Posting it as a small optional thing, not a claim that mount is solved — easy to drop if the tradeoff isn't worth it.
