### PR TITLE
lazy deep tracking via a coarse segment tier (mount ≈ stock)

### DIFF
--- a/src/signals/SignalProvider.tsx
+++ b/src/signals/SignalProvider.tsx
@@ -13,18 +13,30 @@ import { changedSegments } from './coarseSegments'
 import type { CoarseSub } from './coarseSegments'
 import { scheduleCallback, shouldYield } from './scheduler'
 
-// Above this many candidates in a single dispatch, the coarse pass (each
-// candidate builds its deferred deep graph + notifies) is time-sliced so it
-// never blocks one frame; below it, running inline avoids scheduler overhead.
-const COARSE_SLICE_THRESHOLD = 64
 import { alienEngine } from './engine'
 import type { SignalEngine } from './types'
+
+// Default for SignalProvider's `sliceThreshold`: above this many candidates in
+// a single dispatch, the coarse first-touch pass is time-sliced (responsive,
+// but updates stagger); below it, it runs inline (atomic — all candidates in
+// one synchronous pass). Override via the prop.
+const DEFAULT_SLICE_THRESHOLD = 64
 
 export interface SignalProviderProps<
   A extends Action<string> = UnknownAction,
   S = unknown,
 > extends ProviderProps<A, S> {
   engine?: SignalEngine
+  /**
+   * Candidate count above which the coarse first-touch build+notify burst is
+   * time-sliced across macrotasks (keeps a huge burst from blocking a frame,
+   * at the cost of updates staggering during that burst). Below it the pass
+   * runs inline in one synchronous, atomic step. Default `64`. Set to
+   * `Infinity` to always run inline (atomic, may block on a large first
+   * touch); set to `0` to always slice. Only affects the first-touch burst —
+   * steady-state updates are always synchronous.
+   */
+  sliceThreshold?: number
 }
 
 export function SignalProvider<
@@ -37,6 +49,7 @@ export function SignalProvider<
     serverState,
     store,
     engine = alienEngine,
+    sliceThreshold = DEFAULT_SLICE_THRESHOLD,
   } = providerProps
 
   // Create signal registry once (lazy init via ref)
@@ -105,7 +118,7 @@ export function SignalProvider<
     }
 
     const runCoarse = (candidates: Set<CoarseSub>): void => {
-      if (!draining && candidates.size < COARSE_SLICE_THRESHOLD) {
+      if (!draining && candidates.size < sliceThreshold) {
         for (const sub of candidates) sub.onCoarseHit()
         return
       }
@@ -157,7 +170,7 @@ export function SignalProvider<
       subscription.tryUnsubscribe()
       subscription.onStateChange = undefined
     }
-  }, [contextValue, previousState])
+  }, [contextValue, previousState, sliceThreshold])
 
   const Context = (context || ReactReduxContext) as Context<
     ReactReduxContextValue<S, A> | null

--- a/src/signals/SignalProvider.tsx
+++ b/src/signals/SignalProvider.tsx
@@ -126,6 +126,13 @@ export function SignalProvider<
         if (!pendingSet.has(sub)) {
           pendingSet.add(sub)
           pending.push(sub)
+          // Drop it from the segment index as soon as it's queued, so a
+          // dispatch arriving mid-drain doesn't re-collect the whole backlog
+          // of already-queued subs (O(unbuilt) per tick during a large
+          // first-touch drain). Safe: the queued build reads the latest
+          // committed state when it runs, so any further change to this
+          // sub's segment while it waits is still picked up.
+          registry.segmentIndex.unregister(sub)
         }
       }
       if (!draining) {

--- a/src/signals/SignalProvider.tsx
+++ b/src/signals/SignalProvider.tsx
@@ -11,6 +11,12 @@ import { createPathSignalRegistry } from './pathSignalRegistry'
 import { reconcileState } from './diff'
 import { changedSegments } from './coarseSegments'
 import type { CoarseSub } from './coarseSegments'
+import { scheduleCallback, shouldYield } from './scheduler'
+
+// Above this many candidates in a single dispatch, the coarse pass (each
+// candidate builds its deferred deep graph + notifies) is time-sliced so it
+// never blocks one frame; below it, running inline avoids scheduler overhead.
+const COARSE_SLICE_THRESHOLD = 64
 import { alienEngine } from './engine'
 import type { SignalEngine } from './types'
 
@@ -71,6 +77,50 @@ export function SignalProvider<
   // + signal diff on each dispatch
   useIsomorphicLayoutEffect(() => {
     const { subscription } = contextValue
+
+    // Gated, time-sliced drain of coarse candidates. A large first-touch
+    // burst (e.g. every hook depends on the one slice that just changed) is
+    // chunked across macrotasks so it never blocks a frame; a small burst
+    // runs inline. Deferring a candidate only delays its re-render — the
+    // value is read fresh from committed state when it finally builds.
+    let pending: CoarseSub[] = []
+    const pendingSet = new Set<CoarseSub>()
+    let draining = false
+    let disposed = false
+
+    const drainChunk = (): void => {
+      if (disposed) return
+      let sub = pending.pop()
+      while (sub !== undefined) {
+        pendingSet.delete(sub)
+        sub.onCoarseHit()
+        if (pending.length > 0 && shouldYield()) break
+        sub = pending.pop()
+      }
+      if (pending.length > 0) {
+        scheduleCallback(drainChunk)
+      } else {
+        draining = false
+      }
+    }
+
+    const runCoarse = (candidates: Set<CoarseSub>): void => {
+      if (!draining && candidates.size < COARSE_SLICE_THRESHOLD) {
+        for (const sub of candidates) sub.onCoarseHit()
+        return
+      }
+      for (const sub of candidates) {
+        if (!pendingSet.has(sub)) {
+          pendingSet.add(sub)
+          pending.push(sub)
+        }
+      }
+      if (!draining) {
+        draining = true
+        scheduleCallback(drainChunk)
+      }
+    }
+
     subscription.onStateChange = () => {
       // Run signal diff BEFORE notifying nested subs, so computed values
       // are up-to-date when useSelector/useSignalSelector read them
@@ -90,7 +140,7 @@ export function SignalProvider<
       if (changed.length > 0) {
         const candidates = new Set<CoarseSub>()
         registry.segmentIndex.collect(changed, candidates)
-        for (const sub of candidates) sub.onCoarseHit()
+        if (candidates.size > 0) runCoarse(candidates)
       }
 
       subscription.notifyNestedSubs()
@@ -101,6 +151,9 @@ export function SignalProvider<
       subscription.notifyNestedSubs()
     }
     return () => {
+      disposed = true
+      pending = []
+      pendingSet.clear()
       subscription.tryUnsubscribe()
       subscription.onStateChange = undefined
     }

--- a/src/signals/SignalProvider.tsx
+++ b/src/signals/SignalProvider.tsx
@@ -9,6 +9,8 @@ import { useIsomorphicLayoutEffect } from '../utils/useIsomorphicLayoutEffect'
 import type { SignalContextValue } from './context'
 import { createPathSignalRegistry } from './pathSignalRegistry'
 import { reconcileState } from './diff'
+import { changedSegments } from './coarseSegments'
+import type { CoarseSub } from './coarseSegments'
 import { alienEngine } from './engine'
 import type { SignalEngine } from './types'
 
@@ -76,6 +78,20 @@ export function SignalProvider<
       const next = store.getState()
       prevStateRef.current = next
       reconcileState(prev, next, registry, engine)
+
+      // Coarse tier: build + notify any deferred (not-yet-built) hooks whose
+      // top-level segment changed this dispatch. Built hooks are already
+      // handled by the deep reconcile above and drop out of the index, so
+      // this only ever touches the lazy ones.
+      const changed = changedSegments(
+        prev as Record<string, unknown>,
+        next as Record<string, unknown>,
+      )
+      if (changed.length > 0) {
+        const candidates = new Set<CoarseSub>()
+        registry.segmentIndex.collect(changed, candidates)
+        for (const sub of candidates) sub.onCoarseHit()
+      }
 
       subscription.notifyNestedSubs()
     }

--- a/src/signals/coarseSegments.ts
+++ b/src/signals/coarseSegments.ts
@@ -1,0 +1,132 @@
+// Coarse (top-level) segment tracking — the cheap tier in front of the
+// deep path-signal graph.
+//
+// A `useSignalSelector` doesn't need its full per-path tracking graph built
+// at mount; it only needs to know which *top-level* state slices ("segments")
+// it reads, so a dispatch can cheaply decide whether the selector could be
+// affected at all. Building the expensive deep graph is then deferred until a
+// segment the selector actually depends on changes for the first time.
+//
+// This module provides the two primitives for that tier:
+//   - `recordSegments` — runs a selector through a shallow proxy that records
+//     only top-level property access, returning the set of segment names.
+//   - `SegmentIndex` — an inverted index `segment -> Set<subscriber>` used to
+//     collect the subscribers a given dispatch could affect.
+
+/**
+ * A subscriber the coarse tier can index by segment. Kept intentionally
+ * minimal — the index only needs identity and the current segment set.
+ */
+export interface CoarseSub {
+  /** Top-level state segments this subscriber currently depends on. */
+  segments: Set<string>
+}
+
+/**
+ * Run `selector` against a shallow proxy of `state` and return the set of
+ * top-level segment names it accessed. Nested values are returned raw (the
+ * proxy only traps the root), so tracking stays O(1)-ish per selector — no
+ * deep proxy tree is built. The selector's return value is discarded; only
+ * the access footprint matters. A throwing selector still yields whatever
+ * segments it touched before throwing.
+ * @param state - The current (raw) root state object
+ * @param selector - The selector to probe
+ * @returns The set of accessed top-level segment names
+ */
+export function recordSegments<S extends object>(
+  state: S,
+  selector: (state: S) => unknown,
+): Set<string> {
+  const segments = new Set<string>()
+  const proxy = new Proxy(state, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string') segments.add(prop)
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+  try {
+    selector(proxy as S)
+  } catch {
+    // Ignore: the segments accessed before the throw are still a valid
+    // (over-approximate) footprint, and re-running against real state is
+    // where an error is surfaced.
+  }
+  return segments
+}
+
+/**
+ * Inverted index mapping a top-level state segment to the subscribers that
+ * depend on it. Over-approximate by design: a subscriber is collected if any
+ * of its segments changed, and the deep tier (or a raw re-run) decides
+ * whether it truly needs to update — so we never miss an update, we only ever
+ * consider a few extra.
+ */
+export class SegmentIndex<Sub extends CoarseSub> {
+  private readonly bySegment = new Map<string, Set<Sub>>()
+
+  /** Add `sub` under each of its current segments. */
+  register(sub: Sub): void {
+    for (const segment of sub.segments) {
+      let set = this.bySegment.get(segment)
+      if (set === undefined) {
+        set = new Set()
+        this.bySegment.set(segment, set)
+      }
+      set.add(sub)
+    }
+  }
+
+  /** Remove `sub` from each of the given segments (its current set by default). */
+  unregister(sub: Sub, segments: Iterable<string> = sub.segments): void {
+    for (const segment of segments) {
+      const set = this.bySegment.get(segment)
+      if (set !== undefined) {
+        set.delete(sub)
+        if (set.size === 0) {
+          this.bySegment.delete(segment)
+        }
+      }
+    }
+  }
+
+  /**
+   * Re-index `sub` after its segment set changed. `sub.segments` must already
+   * hold the new set; `prevSegments` is the set it was registered under.
+   */
+  reindex(sub: Sub, prevSegments: Set<string>): void {
+    for (const segment of prevSegments) {
+      if (!sub.segments.has(segment)) {
+        const set = this.bySegment.get(segment)
+        if (set !== undefined) {
+          set.delete(sub)
+          if (set.size === 0) this.bySegment.delete(segment)
+        }
+      }
+    }
+    for (const segment of sub.segments) {
+      if (!prevSegments.has(segment)) {
+        let set = this.bySegment.get(segment)
+        if (set === undefined) {
+          set = new Set()
+          this.bySegment.set(segment, set)
+        }
+        set.add(sub)
+      }
+    }
+  }
+
+  /** Add every subscriber of any changed segment into `out`. */
+  collect(changedSegments: Iterable<string>, out: Set<Sub>): void {
+    for (const segment of changedSegments) {
+      const set = this.bySegment.get(segment)
+      if (set !== undefined) {
+        for (const sub of set) out.add(sub)
+      }
+    }
+  }
+
+  /** Number of indexed segments (for tests/diagnostics). */
+  segmentCount(): number {
+    return this.bySegment.size
+  }
+}

--- a/src/signals/coarseSegments.ts
+++ b/src/signals/coarseSegments.ts
@@ -70,7 +70,11 @@ export function recordSegments<S extends object>(
 export class SegmentIndex<Sub extends CoarseSub> {
   private readonly bySegment = new Map<string, Set<Sub>>()
 
-  /** Add `sub` under each of its current segments. */
+  /**
+   * Add `sub` under each of its current segments.
+   * @param sub - The subscriber to index
+   * @returns Nothing
+   */
   register(sub: Sub): void {
     for (const segment of sub.segments) {
       let set = this.bySegment.get(segment)
@@ -82,7 +86,12 @@ export class SegmentIndex<Sub extends CoarseSub> {
     }
   }
 
-  /** Remove `sub` from each of the given segments (its current set by default). */
+  /**
+   * Remove `sub` from each of the given segments (its current set by default).
+   * @param sub - The subscriber to remove
+   * @param segments - The segments to remove it from; defaults to its current set
+   * @returns Nothing
+   */
   unregister(sub: Sub, segments: Iterable<string> = sub.segments): void {
     for (const segment of segments) {
       const set = this.bySegment.get(segment)
@@ -95,7 +104,12 @@ export class SegmentIndex<Sub extends CoarseSub> {
     }
   }
 
-  /** Add every subscriber of any changed segment into `out`. */
+  /**
+   * Add every subscriber of any changed segment into `out`.
+   * @param changedSegments - The segments that changed in a dispatch
+   * @param out - The set collecting the affected subscribers
+   * @returns Nothing
+   */
   collect(changedSegments: Iterable<string>, out: Set<Sub>): void {
     for (const segment of changedSegments) {
       const set = this.bySegment.get(segment)
@@ -105,7 +119,10 @@ export class SegmentIndex<Sub extends CoarseSub> {
     }
   }
 
-  /** Number of indexed segments (for tests/diagnostics). */
+  /**
+   * Number of indexed segments (for tests/diagnostics).
+   * @returns The count of segments currently in the index
+   */
   segmentCount(): number {
     return this.bySegment.size
   }

--- a/src/signals/coarseSegments.ts
+++ b/src/signals/coarseSegments.ts
@@ -95,32 +95,6 @@ export class SegmentIndex<Sub extends CoarseSub> {
     }
   }
 
-  /**
-   * Re-index `sub` after its segment set changed. `sub.segments` must already
-   * hold the new set; `prevSegments` is the set it was registered under.
-   */
-  reindex(sub: Sub, prevSegments: Set<string>): void {
-    for (const segment of prevSegments) {
-      if (!sub.segments.has(segment)) {
-        const set = this.bySegment.get(segment)
-        if (set !== undefined) {
-          set.delete(sub)
-          if (set.size === 0) this.bySegment.delete(segment)
-        }
-      }
-    }
-    for (const segment of sub.segments) {
-      if (!prevSegments.has(segment)) {
-        let set = this.bySegment.get(segment)
-        if (set === undefined) {
-          set = new Set()
-          this.bySegment.set(segment, set)
-        }
-        set.add(sub)
-      }
-    }
-  }
-
   /** Add every subscriber of any changed segment into `out`. */
   collect(changedSegments: Iterable<string>, out: Set<Sub>): void {
     for (const segment of changedSegments) {

--- a/src/signals/coarseSegments.ts
+++ b/src/signals/coarseSegments.ts
@@ -20,6 +20,12 @@
 export interface CoarseSub {
   /** Top-level state segments this subscriber currently depends on. */
   segments: Set<string>
+  /**
+   * Invoked by the provider when a dispatch changed one of this subscriber's
+   * segments — i.e. the selector could now produce a different value. The
+   * subscriber decides what to do (build its deep graph, re-run, notify).
+   */
+  onCoarseHit(): void
 }
 
 /**
@@ -129,4 +135,29 @@ export class SegmentIndex<Sub extends CoarseSub> {
   segmentCount(): number {
     return this.bySegment.size
   }
+}
+
+/**
+ * Top-level segments whose value changed by reference between two state
+ * snapshots (plus added/removed keys). O(number of top-level keys) — this is
+ * the cheap change detection that replaces walking the full state tree, sound
+ * for immutably-updated state: a segment whose reference is unchanged cannot
+ * have produced a different selector result.
+ * @param prev - The previous root state
+ * @param next - The next root state
+ * @returns The list of changed top-level segment names
+ */
+export function changedSegments(
+  prev: Record<string, unknown>,
+  next: Record<string, unknown>,
+): string[] {
+  if (prev === next) return []
+  const result: string[] = []
+  for (const key of Object.keys(next)) {
+    if (prev[key] !== next[key]) result.push(key)
+  }
+  for (const key of Object.keys(prev)) {
+    if (!(key in next)) result.push(key)
+  }
+  return result
 }

--- a/src/signals/index.ts
+++ b/src/signals/index.ts
@@ -24,4 +24,6 @@ export type { PathSignalRegistry } from './pathSignalRegistry'
 
 export { createTrackingProxy, unwrap } from './trackingProxy'
 
+export { default as shallowEqual } from '../utils/shallowEqual'
+
 export { diffAndUpdateSignals, reconcileState } from './diff'

--- a/src/signals/pathSignalRegistry.ts
+++ b/src/signals/pathSignalRegistry.ts
@@ -1,5 +1,7 @@
 import { encodePathSegment } from './arrayKeys'
 import type { ArrayMeta } from './arrayKeys'
+import { SegmentIndex } from './coarseSegments'
+import type { CoarseSub } from './coarseSegments'
 import type { LeafObjectTracker, ProxyCache } from './trackingProxy'
 import type { PathKey, ReactiveSignal, SignalEngine } from './types'
 
@@ -48,6 +50,10 @@ export interface PathSignalRegistry {
 
   /** Proxy cache for reusing proxies across evaluations (keyed by object identity). */
   proxyCache: ProxyCache
+
+  /** Coarse tier: top-level segment -> subscribers, for cheaply deciding
+   *  which selectors a dispatch could affect before touching the deep graph. */
+  segmentIndex: SegmentIndex<CoarseSub>
 
   /** Holder for the leaf tracker of the evaluation currently running.
    *  Proxies read this at trap time instead of closing over a tracker,
@@ -174,6 +180,8 @@ export function createPathSignalRegistry(
   // Proxy cache: keyed by target object identity.
   // Reuses proxies for unchanged Immer subtrees across state snapshots.
   const proxyWeakMap: ProxyCache = new WeakMap()
+  // Coarse top-level segment index (see coarseSegments.ts).
+  const segmentIndex = new SegmentIndex<CoarseSub>()
   // Per-array metadata for identity-based tracking.
   // Maps array path → ArrayMeta (keyField + entityMap).
   const arrayMetas = new Map<string, ArrayMeta>()
@@ -314,6 +322,8 @@ export function createPathSignalRegistry(
     },
 
     proxyCache: proxyWeakMap,
+
+    segmentIndex,
 
     leafTrackerHolder: { current: undefined },
 

--- a/src/signals/scheduler.ts
+++ b/src/signals/scheduler.ts
@@ -1,0 +1,105 @@
+// Host scheduling primitive, vendored from React's Scheduler so the coarse
+// tier can time-slice a large burst of deferred-graph builds / notifications
+// with the same, proven semantics.
+// Source: react/packages/scheduler/src/forks/Scheduler.js (line refs below).
+//
+// We copy only what a chunked pass needs — a macrotask scheduler plus a
+// `shouldYield()` deadline — not the priority min-heap.
+//
+// DEVIATION FROM REACT (improvement): React yields early, before the 5ms
+// frame budget, when it knows a paint is pending (`needsPaint`, set by its own
+// commit phase — a signal a library doesn't have). We reproduce that early
+// yield for the one signal a library does have: `navigator.scheduling
+// .isInputPending()`, so an in-progress pass releases the main thread the
+// instant the user interacts.
+
+// Scheduler.js:11 — frameYieldMs
+const frameInterval = 5
+
+// After blocking this long we yield even while input keeps arriving, so a
+// burst of input can't starve the pass indefinitely.
+const maxYieldInterval = 300
+
+let getCurrentTime: () => number
+if (typeof performance === 'object' && typeof performance.now === 'function') {
+  const localPerformance = performance
+  getCurrentTime = () => localPerformance.now()
+} else {
+  const localDate = Date
+  const initialTime = localDate.now()
+  getCurrentTime = () => localDate.now() - initialTime
+}
+
+export { getCurrentTime }
+
+type Scheduling = {
+  isInputPending?: (options?: { includeContinuous?: boolean }) => boolean
+}
+const scheduling: Scheduling | undefined =
+  typeof navigator !== 'undefined'
+    ? (navigator as unknown as { scheduling?: Scheduling }).scheduling
+    : undefined
+const isInputPending =
+  scheduling && typeof scheduling.isInputPending === 'function'
+    ? scheduling.isInputPending.bind(scheduling)
+    : null
+const continuousOptions = { includeContinuous: true }
+
+let startTime = -1
+let needsPaint = false
+
+export function requestPaint(): void {
+  needsPaint = true
+}
+
+// Scheduler.js:459-472 — shouldYieldToHost, extended with the isInputPending
+// early-yield described above.
+export function shouldYield(): boolean {
+  if (needsPaint) {
+    return true
+  }
+  const timeElapsed = getCurrentTime() - startTime
+  if (timeElapsed < frameInterval) {
+    if (
+      isInputPending !== null &&
+      timeElapsed < maxYieldInterval &&
+      isInputPending(continuousOptions)
+    ) {
+      return true
+    }
+    return false
+  }
+  return true
+}
+
+// Macrotask transport. Scheduler.js:530-561 prefers a single reused
+// MessageChannel (avoids setTimeout's 4ms clamp), then setTimeout. `startTime`
+// is reset before each callback so `shouldYield()` measures the block length
+// of this chunk (Scheduler.js:504-507).
+let queue: Array<() => void> = []
+let channel: MessageChannel | undefined
+
+function flush() {
+  const pending = queue
+  queue = []
+  for (let i = 0; i < pending.length; i++) {
+    needsPaint = false
+    startTime = getCurrentTime()
+    pending[i]()
+  }
+}
+
+export function scheduleCallback(callback: () => void): void {
+  queue.push(callback)
+  if (queue.length > 1) return
+
+  if (typeof MessageChannel !== 'undefined') {
+    if (!channel) {
+      channel = new MessageChannel()
+      channel.port1.onmessage = flush
+    }
+    channel.port2.postMessage(null)
+  } else {
+    setTimeout(flush, 0)
+  }
+}

--- a/src/signals/useSignalSelector.ts
+++ b/src/signals/useSignalSelector.ts
@@ -18,6 +18,8 @@ import {
   type LeafObjectTracker,
 } from './trackingProxy'
 import { untrackResult } from './untrack'
+import { recordSegments } from './coarseSegments'
+import type { CoarseSub } from './coarseSegments'
 
 const { useRef, useMemo, useEffect, useSyncExternalStore, useDebugValue } =
   React
@@ -97,6 +99,9 @@ const useSignalSelectorImpl = <S, R>(
     let version = 0
     let notifyReact: (() => void) | null = null
     let suppressNotify = false
+    // Coarse-tier registration for this hook (top-level segments it reads),
+    // kept so subscribe/cleanup can (un)register it in the segment index.
+    let coarseSub: CoarseSub | null = null
     // Set when the selector threw during an effect re-evaluation (classic
     // zombie child: an entity was removed while a component selecting it
     // is still mounted). getSnapshot retries and rethrows if it persists.
@@ -309,6 +314,16 @@ const useSignalSelectorImpl = <S, R>(
       subscribe(onStoreChange: () => void): () => void {
         notifyReact = onStoreChange
 
+        // Register the coarse top-level segments this selector reads, so a
+        // dispatch can cheaply tell whether this hook could be affected.
+        coarseSub = {
+          segments: recordSegments(
+            store.getState() as object,
+            selectorRef.current as (s: object) => unknown,
+          ),
+        }
+        registry.segmentIndex.register(coarseSub)
+
         // Create an effect that fires when the computed value changes.
         // We apply the user's equalityFn here since alien-signals
         // doesn't support custom equality per-computed.
@@ -352,6 +367,10 @@ const useSignalSelectorImpl = <S, R>(
 
         return () => {
           notifyReact = null
+          if (coarseSub !== null) {
+            registry.segmentIndex.unregister(coarseSub)
+            coarseSub = null
+          }
           dispose()
         }
       },

--- a/src/signals/useSignalSelector.ts
+++ b/src/signals/useSignalSelector.ts
@@ -108,6 +108,11 @@ const useSignalSelectorImpl = <S, R>(
     // mounting N hooks doesn't build N deep graphs up front.
     let built = false
     let disposeEffect: (() => void) | null = null
+    // The store state `currentResult` was last computed from, while unbuilt.
+    // Lets getSnapshot recompute from the latest state (only when the state
+    // ref changed, so the snapshot stays referentially stable) — see
+    // getSnapshot for why this prevents tearing during the deferred window.
+    let lastSnapshotState: unknown = null
     // Set when the selector threw during an effect re-evaluation (classic
     // zombie child: an entity was removed while a component selecting it
     // is still mounted). getSnapshot retries and rethrows if it persists.
@@ -310,7 +315,9 @@ const useSignalSelectorImpl = <S, R>(
     // established lazily on subscribe. A selector that throws
     // deterministically still throws here, during render (stock parity).
     try {
-      currentResult = untrackResult(selectorRef.current(store.getState() as S))
+      const state = store.getState()
+      lastSnapshotState = state
+      currentResult = untrackResult(selectorRef.current(state as S))
     } catch (e) {
       pendingError = e
       throw pendingError
@@ -394,7 +401,10 @@ const useSignalSelectorImpl = <S, R>(
           coarseSub = {
             segments,
             onCoarseHit: () => {
-              if (built) return
+              // Skip if already built, or if the hook unsubscribed while this
+              // candidate was waiting in a sliced drain (cleanup nulls
+              // notifyReact) — don't build a graph for a dead hook.
+              if (built || notifyReact === null) return
               buildEffect()
               // buildEffect's first run evaluated the computed against the
               // just-committed state without notifying. Surface this
@@ -450,6 +460,31 @@ const useSignalSelectorImpl = <S, R>(
             throw pendingError
           }
         }
+
+        if (!built) {
+          // Not yet upgraded to the deep signal graph. Behave like stock
+          // useSelector: recompute from the LATEST committed state whenever
+          // it changed (skip when the state ref is unchanged so the snapshot
+          // stays referentially stable for useSyncExternalStore). This closes
+          // the tearing window from the coarse tier's deferred notification —
+          // if an ancestor force-renders this hook before its deferred build
+          // runs, it still reflects the latest state, consistent with built
+          // siblings that update synchronously via reconcile.
+          const state = store.getState()
+          if (state !== lastSnapshotState) {
+            lastSnapshotState = state
+            try {
+              const fresh = untrackResult(selectorRef.current(state as S))
+              if (!equalityFnRef.current(currentResult, fresh)) {
+                currentResult = fresh
+              }
+            } catch (e) {
+              pendingError = e
+              throw pendingError
+            }
+          }
+        }
+
         return currentResult
       },
 

--- a/src/signals/useSignalSelector.ts
+++ b/src/signals/useSignalSelector.ts
@@ -102,6 +102,12 @@ const useSignalSelectorImpl = <S, R>(
     // Coarse-tier registration for this hook (top-level segments it reads),
     // kept so subscribe/cleanup can (un)register it in the segment index.
     let coarseSub: CoarseSub | null = null
+    // Lazy deep-graph state: the alien effect that establishes path signals
+    // and drives React notifications is built on the first coarse hit (a
+    // dispatch that changed one of this hook's segments), not at mount — so
+    // mounting N hooks doesn't build N deep graphs up front.
+    let built = false
+    let disposeEffect: (() => void) | null = null
     // Set when the selector threw during an effect re-evaluation (classic
     // zombie child: an entity was removed while a component selecting it
     // is still mounted). getSnapshot retries and rethrows if it persists.
@@ -310,60 +316,109 @@ const useSignalSelectorImpl = <S, R>(
       throw pendingError
     }
 
+    if (process.env.NODE_ENV !== 'production') {
+      // Dev-mode selector checks normally ride the computed's first eval,
+      // which is now deferred to the first coarse hit. Run them here at mount
+      // so their timing/frequency ('once' vs 'always') is unchanged. They
+      // use raw state — the stability re-run and identity check don't need
+      // the tracking proxy — and consume `firstRun`, so the later computed
+      // eval only re-checks under 'always'.
+      runDevModeChecks(currentResult, store.getState() as S)
+    }
+
+    // Build the alien effect that drives React notifications from the deep
+    // signal graph. Its first run evaluates the computed once — establishing
+    // path-signal dependencies via the tracking proxy — without notifying;
+    // afterwards alien re-runs it whenever a tracked path changes. Deferred
+    // until the first coarse hit, so mount doesn't build N deep graphs.
+    const buildEffect = (): void => {
+      built = true
+      let isFirst = true
+      disposeEffect = engine.effect(() => {
+        const newValue = selectorComputed.get()
+
+        if (pendingError !== null) {
+          // The evaluation threw (newValue is the SELECTOR_THREW sentinel —
+          // never adopt it). Notify React so getSnapshot can retry and
+          // surface or dissolve the error.
+          isFirst = false
+          if (!suppressNotify) {
+            notifyReact?.()
+          }
+          return
+        }
+
+        if (isFirst) {
+          // First effect run — just establish tracking, don't notify.
+          isFirst = false
+          return
+        }
+
+        if (suppressNotify) {
+          // Render-phase selector swap (setSelector): adopt the value so the
+          // equality baseline is current, but let the ongoing render pick it
+          // up via getSnapshot instead of scheduling another render.
+          currentResult = newValue
+          return
+        }
+
+        // Apply user's equality function.
+        if (!equalityFnRef.current(currentResult, newValue)) {
+          currentResult = newValue
+          version++
+          notifyReact?.()
+        }
+      })
+    }
+
     return {
       subscribe(onStoreChange: () => void): () => void {
         notifyReact = onStoreChange
 
-        // Register the coarse top-level segments this selector reads, so a
-        // dispatch can cheaply tell whether this hook could be affected.
-        coarseSub = {
-          segments: recordSegments(
-            store.getState() as object,
-            selectorRef.current as (s: object) => unknown,
-          ),
+        // Record the coarse top-level segments this selector reads. Sound for
+        // immutable state: if none of them changed by reference, the selector
+        // result cannot have changed, so the hook needs no update.
+        const segments = recordSegments(
+          store.getState() as object,
+          selectorRef.current as (s: object) => unknown,
+        )
+
+        if (segments.size === 0) {
+          // No discrete top-level segment (identity selector, key
+          // enumeration, …): the coarse tier can't gate it — build the deep
+          // graph eagerly so it's driven normally and never misses an update.
+          buildEffect()
+        } else {
+          // Defer the deep graph: register in the segment index and build on
+          // the first dispatch that changes one of these segments.
+          coarseSub = {
+            segments,
+            onCoarseHit: () => {
+              if (built) return
+              buildEffect()
+              // buildEffect's first run evaluated the computed against the
+              // just-committed state without notifying. Surface this
+              // dispatch's change now by comparing to the seeded value.
+              if (pendingError !== null) {
+                notifyReact?.()
+              } else {
+                const newValue = selectorComputed.get()
+                if (!equalityFnRef.current(currentResult, newValue)) {
+                  currentResult = newValue
+                  version++
+                  notifyReact?.()
+                }
+              }
+              // Now driven by the deep graph via reconcile — drop the coarse
+              // registration so it isn't hit again.
+              if (coarseSub !== null) {
+                registry.segmentIndex.unregister(coarseSub)
+                coarseSub = null
+              }
+            },
+          }
+          registry.segmentIndex.register(coarseSub)
         }
-        registry.segmentIndex.register(coarseSub)
-
-        // Create an effect that fires when the computed value changes.
-        // We apply the user's equalityFn here since alien-signals
-        // doesn't support custom equality per-computed.
-        let isFirst = true
-        const dispose = engine.effect(() => {
-          const newValue = selectorComputed.get()
-
-          if (pendingError !== null) {
-            // The evaluation threw (newValue is the SELECTOR_THREW
-            // sentinel — never adopt it). Notify React so getSnapshot
-            // can retry and surface or dissolve the error.
-            isFirst = false
-            if (!suppressNotify) {
-              notifyReact?.()
-            }
-            return
-          }
-
-          if (isFirst) {
-            // First effect run — just establish tracking, don't notify
-            isFirst = false
-            return
-          }
-
-          if (suppressNotify) {
-            // Render-phase selector swap (setSelector): adopt the value
-            // so the equality baseline is current, but let the ongoing
-            // render pick it up via getSnapshot instead of scheduling
-            // another render.
-            currentResult = newValue
-            return
-          }
-
-          // Apply user's equality function
-          if (!equalityFnRef.current(currentResult, newValue)) {
-            currentResult = newValue
-            version++
-            notifyReact?.()
-          }
-        })
 
         return () => {
           notifyReact = null
@@ -371,7 +426,11 @@ const useSignalSelectorImpl = <S, R>(
             registry.segmentIndex.unregister(coarseSub)
             coarseSub = null
           }
-          dispose()
+          if (disposeEffect !== null) {
+            disposeEffect()
+            disposeEffect = null
+          }
+          built = false
         }
       },
 

--- a/src/signals/useSignalSelector.ts
+++ b/src/signals/useSignalSelector.ts
@@ -288,10 +288,20 @@ const useSignalSelectorImpl = <S, R>(
       }
     })
 
-    // Initialize with current value. A selector that throws on mount
-    // surfaces here, during render — same as stock useSelector.
-    currentResult = selectorComputed.get()
-    if (pendingError !== null) {
+    // MOUNT OPT: seed the first-render value with a cheap UNTRACKED run of
+    // the selector against raw state, instead of the eager tracked
+    // `selectorComputed.get()`. Building the tracking proxy + registering
+    // path signals (the expensive part) is deferred to the first
+    // `engine.effect` run inside subscribe(), which React invokes in the
+    // commit phase — off the render-blocking path. The raw run yields the
+    // same value (`untrackResult` is a no-op on already-raw state), so the
+    // first-render snapshot is unchanged; the dependency graph is
+    // established lazily on subscribe. A selector that throws
+    // deterministically still throws here, during render (stock parity).
+    try {
+      currentResult = untrackResult(selectorRef.current(store.getState() as S))
+    } catch (e) {
+      pendingError = e
       throw pendingError
     }
 

--- a/test/signals/coarseEmptySegments.spec.tsx
+++ b/test/signals/coarseEmptySegments.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import * as rtl from '@testing-library/react'
+import React from 'react'
+import { configureStore, createSlice } from '@reduxjs/toolkit'
+import { SignalProvider, useSignalSelector } from '../../src/signals'
+
+function makeStore() {
+  const slice = createSlice({
+    name: 's',
+    initialState: { count: 0 },
+    reducers: { inc: (s) => void s.count++ },
+  })
+  const store = configureStore({ reducer: slice.reducer })
+  return { store, inc: slice.actions.inc }
+}
+
+// A selector that reads no top-level segment (nothing for the coarse recorder
+// to attribute) can't be gated by the coarse tier, so it falls back to an
+// eager deep build. It must still mount and render, and coexist with normal
+// segmented selectors.
+describe('coarse tier — empty-segment selectors fall back to eager build', () => {
+  it('a selector that reads no state segment renders, and a segmented one alongside still updates', () => {
+    const { store, inc } = makeStore()
+
+    function Comp() {
+      const constant = useSignalSelector(() => 42)
+      const count = useSignalSelector((s: { count: number }) => s.count)
+      return (
+        <div data-testid="v">
+          {constant}:{count}
+        </div>
+      )
+    }
+
+    rtl.render(
+      <SignalProvider store={store}>
+        <Comp />
+      </SignalProvider>,
+    )
+    expect(rtl.screen.getByTestId('v').textContent).toBe('42:0')
+
+    rtl.act(() => {
+      store.dispatch(inc())
+    })
+    expect(rtl.screen.getByTestId('v').textContent).toBe('42:1')
+  })
+})

--- a/test/signals/coarseSegments.spec.ts
+++ b/test/signals/coarseSegments.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  changedSegments,
   recordSegments,
   SegmentIndex,
   type CoarseSub,
@@ -42,6 +43,7 @@ describe('recordSegments', () => {
 describe('SegmentIndex', () => {
   const sub = (...segments: string[]): CoarseSub => ({
     segments: new Set(segments),
+    onCoarseHit() {},
   })
 
   it('collects subscribers of changed segments (union, deduped)', () => {
@@ -97,5 +99,29 @@ describe('SegmentIndex', () => {
 
     index.collect(['c'], out)
     expect(out).toEqual(new Set([s1])) // now under 'c'
+  })
+})
+
+describe('changedSegments', () => {
+  it('returns top-level keys whose reference changed', () => {
+    const a = { x: 1 }
+    const b = { y: 2 }
+    const prev = { a, b, n: 1 }
+    const next = { a, b: { y: 3 }, n: 1 }
+    expect(changedSegments(prev, next)).toEqual(['b'])
+  })
+
+  it('returns [] for the same reference', () => {
+    const s = { a: 1 }
+    expect(changedSegments(s, s)).toEqual([])
+  })
+
+  it('detects added and removed top-level keys', () => {
+    expect(changedSegments({ a: 1 }, { a: 1, b: 2 })).toEqual(['b'])
+    expect(changedSegments({ a: 1, b: 2 }, { a: 1 })).toEqual(['b'])
+  })
+
+  it('detects changed primitive segments', () => {
+    expect(changedSegments({ a: 1, b: 2 }, { a: 1, b: 5 })).toEqual(['b'])
   })
 })

--- a/test/signals/coarseSegments.spec.ts
+++ b/test/signals/coarseSegments.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  recordSegments,
+  SegmentIndex,
+  type CoarseSub,
+} from '../../src/signals/coarseSegments'
+
+describe('recordSegments', () => {
+  const state = {
+    a: { deep: { value: 1 } },
+    b: [10, 20, 30],
+    c: 'hi',
+  }
+
+  it('records only the top-level segments a selector reads', () => {
+    expect(recordSegments(state, (s: typeof state) => s.a.deep.value)).toEqual(
+      new Set(['a']),
+    )
+    expect(recordSegments(state, (s: typeof state) => s.b[1])).toEqual(
+      new Set(['b']),
+    )
+    expect(
+      recordSegments(state, (s: typeof state) => `${s.a.deep.value}-${s.c}`),
+    ).toEqual(new Set(['a', 'c']))
+  })
+
+  it('does not record nested property access as a segment', () => {
+    const segments = recordSegments(state, (s: typeof state) => s.a.deep.value)
+    expect(segments.has('deep')).toBe(false)
+    expect(segments.has('value')).toBe(false)
+  })
+
+  it('keeps the segments touched before a selector throws', () => {
+    const segments = recordSegments(state, (s: any) => {
+      void s.a
+      throw new Error('boom')
+    })
+    expect(segments.has('a')).toBe(true)
+  })
+})
+
+describe('SegmentIndex', () => {
+  const sub = (...segments: string[]): CoarseSub => ({
+    segments: new Set(segments),
+  })
+
+  it('collects subscribers of changed segments (union, deduped)', () => {
+    const index = new SegmentIndex<CoarseSub>()
+    const s1 = sub('a', 'b')
+    const s2 = sub('b')
+    const s3 = sub('c')
+    index.register(s1)
+    index.register(s2)
+    index.register(s3)
+
+    const out = new Set<CoarseSub>()
+    index.collect(['b'], out)
+    expect(out).toEqual(new Set([s1, s2]))
+
+    out.clear()
+    index.collect(['a', 'c'], out)
+    expect(out).toEqual(new Set([s1, s3]))
+  })
+
+  it('ignores changed segments with no subscribers', () => {
+    const index = new SegmentIndex<CoarseSub>()
+    index.register(sub('a'))
+    const out = new Set<CoarseSub>()
+    index.collect(['zzz'], out)
+    expect(out.size).toBe(0)
+  })
+
+  it('unregister removes a subscriber and prunes empty segments', () => {
+    const index = new SegmentIndex<CoarseSub>()
+    const s1 = sub('a')
+    index.register(s1)
+    expect(index.segmentCount()).toBe(1)
+    index.unregister(s1)
+    expect(index.segmentCount()).toBe(0)
+    const out = new Set<CoarseSub>()
+    index.collect(['a'], out)
+    expect(out.size).toBe(0)
+  })
+
+  it('reindex moves a subscriber to its new segment set', () => {
+    const index = new SegmentIndex<CoarseSub>()
+    const s1 = sub('a', 'b')
+    index.register(s1)
+
+    const prev = new Set(s1.segments)
+    s1.segments = new Set(['b', 'c'])
+    index.reindex(s1, prev)
+
+    const out = new Set<CoarseSub>()
+    index.collect(['a'], out)
+    expect(out.size).toBe(0) // no longer under 'a'
+
+    index.collect(['c'], out)
+    expect(out).toEqual(new Set([s1])) // now under 'c'
+  })
+})

--- a/test/signals/coarseSegments.spec.ts
+++ b/test/signals/coarseSegments.spec.ts
@@ -84,22 +84,6 @@ describe('SegmentIndex', () => {
     expect(out.size).toBe(0)
   })
 
-  it('reindex moves a subscriber to its new segment set', () => {
-    const index = new SegmentIndex<CoarseSub>()
-    const s1 = sub('a', 'b')
-    index.register(s1)
-
-    const prev = new Set(s1.segments)
-    s1.segments = new Set(['b', 'c'])
-    index.reindex(s1, prev)
-
-    const out = new Set<CoarseSub>()
-    index.collect(['a'], out)
-    expect(out.size).toBe(0) // no longer under 'a'
-
-    index.collect(['c'], out)
-    expect(out).toEqual(new Set([s1])) // now under 'c'
-  })
 })
 
 describe('changedSegments', () => {

--- a/test/signals/coarseTearing.spec.tsx
+++ b/test/signals/coarseTearing.spec.tsx
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import * as rtl from '@testing-library/react'
+import React from 'react'
+import { flushSync } from 'react-dom'
+import { configureStore, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { SignalProvider, useSignalSelector } from '../../src/signals'
+
+// The coarse tier time-slices the first-touch burst: when many hooks depend on
+// the one segment that just changed, their deep-graph build + notify is
+// deferred across macrotasks instead of running synchronously. This must NOT
+// let a hook render a stale value while sibling hooks render the new one — the
+// desync-with-different-store-values bug. These tests force exactly that
+// window (N >= the slice threshold, so the dispatch defers) and assert
+// consistency.
+
+const N = 80 // above COARSE_SLICE_THRESHOLD (64) so a full-segment change slices
+
+function makeStore() {
+  const slice = createSlice({
+    name: 's',
+    initialState: {
+      list: Array.from({ length: N }, () => ({ v: 0 })),
+      other: 0,
+    },
+    reducers: {
+      setAll: (state, action: PayloadAction<number>) => {
+        state.list = state.list.map(() => ({ v: action.payload }))
+      },
+    },
+  })
+  const store = configureStore({ reducer: slice.reducer })
+  return { store, setAll: slice.actions.setAll }
+}
+
+type RootState = ReturnType<ReturnType<typeof makeStore>['store']['getState']>
+
+let forceRerender: () => void = () => {}
+
+// Stable (hoisted) selector per index. This matters: an inline selector is a
+// new function each render, which triggers the hook's render-phase
+// setSelector → a deep recompute that refreshes the value anyway, masking the
+// getSnapshot path under test. Stable selectors are the common case and the
+// one where getSnapshot alone must keep an unbuilt hook consistent.
+const selectors = Array.from(
+  { length: N },
+  (_, i) => (s: RootState) => s.list[i].v,
+)
+
+function Leaf({ i }: { i: number }) {
+  const v = useSignalSelector(selectors[i])
+  return <span data-testid={`leaf-${i}`}>{v}</span>
+}
+
+function Parent() {
+  const [, setTick] = React.useState(0)
+  forceRerender = () => setTick((t) => t + 1)
+  return (
+    <>
+      {Array.from({ length: N }, (_, i) => (
+        <Leaf key={i} i={i} />
+      ))}
+    </>
+  )
+}
+
+const flushMacrotasks = () =>
+  rtl.act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+describe('coarse tier — no desync during the sliced first-touch window', () => {
+  it('a hook force-rendered before its deferred build shows the latest value, not a stale one', () => {
+    const { store, setAll } = makeStore()
+    rtl.render(
+      <SignalProvider store={store}>
+        <Parent />
+      </SignalProvider>,
+    )
+
+    // Everyone starts at 0.
+    expect(rtl.screen.getByTestId('leaf-0').textContent).toBe('0')
+    expect(rtl.screen.getByTestId(`leaf-${N - 1}`).textContent).toBe('0')
+
+    // Change the whole `list` segment. All N hooks are candidates, which is
+    // above the slice threshold — so the build+notify is deferred, and no
+    // hook re-renders synchronously (still showing 0).
+    rtl.act(() => {
+      store.dispatch(setAll(5))
+    })
+    expect(rtl.screen.getByTestId('leaf-0').textContent).toBe('0')
+
+    // Now an ancestor re-renders synchronously (flushSync commits it before
+    // the sliced drain macrotask can run), forcing every leaf to re-render
+    // WHILE their builds are still queued. We assert immediately, inside the
+    // tearing window: each leaf must read the latest committed state, not the
+    // stale seed — otherwise built/synchronous siblings and these deferred
+    // ones would show different store values at the same time.
+    flushSync(() => {
+      forceRerender()
+    })
+    for (let i = 0; i < N; i++) {
+      expect(rtl.screen.getByTestId(`leaf-${i}`).textContent).toBe('5')
+    }
+  })
+
+  it('deferred hooks converge to the latest value once the drain flushes (liveness)', async () => {
+    const { store, setAll } = makeStore()
+    rtl.render(
+      <SignalProvider store={store}>
+        <Parent />
+      </SignalProvider>,
+    )
+
+    rtl.act(() => {
+      store.dispatch(setAll(7))
+    })
+
+    // Without any forced re-render, the sliced drain must still eventually
+    // build + notify every hook so it reflects the new value.
+    await flushMacrotasks()
+
+    for (let i = 0; i < N; i++) {
+      expect(rtl.screen.getByTestId(`leaf-${i}`).textContent).toBe('7')
+    }
+  })
+
+  it('stays consistent across a second change after warmup (now built, synchronous)', async () => {
+    const { store, setAll } = makeStore()
+    rtl.render(
+      <SignalProvider store={store}>
+        <Parent />
+      </SignalProvider>,
+    )
+
+    // First change + flush warms up (builds) every hook.
+    rtl.act(() => {
+      store.dispatch(setAll(1))
+    })
+    await flushMacrotasks()
+
+    // A second change now goes through the deep graph synchronously; all
+    // hooks update together to the same latest value.
+    rtl.act(() => {
+      store.dispatch(setAll(2))
+    })
+    await flushMacrotasks()
+
+    for (let i = 0; i < N; i++) {
+      expect(rtl.screen.getByTestId(`leaf-${i}`).textContent).toBe('2')
+    }
+  })
+})

--- a/test/signals/coarseTearing.spec.tsx
+++ b/test/signals/coarseTearing.spec.tsx
@@ -124,6 +124,32 @@ describe('coarse tier — no desync during the sliced first-touch window', () =>
     }
   })
 
+  it('a queued hook still reflects a later change to its segment when it builds', async () => {
+    const { store, setAll } = makeStore()
+    rtl.render(
+      <SignalProvider store={store}>
+        <Parent />
+      </SignalProvider>,
+    )
+
+    // First change queues all N hooks for the sliced drain (and drops them
+    // from the segment index so a mid-drain dispatch doesn't re-collect them).
+    rtl.act(() => {
+      store.dispatch(setAll(5))
+    })
+    // A second change to the same segment arrives before the drain runs.
+    // The queued builds must pick up this latest value, not the queued-time 5.
+    rtl.act(() => {
+      store.dispatch(setAll(7))
+    })
+
+    await flushMacrotasks()
+
+    for (let i = 0; i < N; i++) {
+      expect(rtl.screen.getByTestId(`leaf-${i}`).textContent).toBe('7')
+    }
+  })
+
   it('sliceThreshold=Infinity runs the first-touch burst inline (atomic)', () => {
     const { store, setAll } = makeStore()
     rtl.render(

--- a/test/signals/coarseTearing.spec.tsx
+++ b/test/signals/coarseTearing.spec.tsx
@@ -124,6 +124,25 @@ describe('coarse tier — no desync during the sliced first-touch window', () =>
     }
   })
 
+  it('sliceThreshold=Infinity runs the first-touch burst inline (atomic)', () => {
+    const { store, setAll } = makeStore()
+    rtl.render(
+      <SignalProvider store={store} sliceThreshold={Infinity}>
+        <Parent />
+      </SignalProvider>,
+    )
+
+    // With slicing disabled, the whole first-touch burst runs synchronously in
+    // the dispatch — every leaf reflects the new value at once, no drain flush
+    // and no forced re-render needed.
+    rtl.act(() => {
+      store.dispatch(setAll(9))
+    })
+    for (let i = 0; i < N; i++) {
+      expect(rtl.screen.getByTestId(`leaf-${i}`).textContent).toBe('9')
+    }
+  })
+
   it('stays consistent across a second change after warmup (now built, synchronous)', async () => {
     const { store, setAll } = makeStore()
     rtl.render(

--- a/test/signals/multiSelectorOverfire.spec.tsx
+++ b/test/signals/multiSelectorOverfire.spec.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import * as rtl from '@testing-library/react'
+import React from 'react'
+import {
+  combineReducers,
+  configureStore,
+  createSlice,
+  type PayloadAction,
+} from '@reduxjs/toolkit'
+import { SignalProvider, useSignalSelector, shallowEqual } from '../../src/signals'
+
+// Mirrors the multi-selector-component benchmark: 4 selectors per card, over
+// slices where several actions change a segment WITHOUT changing the field the
+// card reads (loginCount≠role, preferences unread, scrollPosition≠sidebar/tab).
+// After warmup those actions must cause ZERO extra renders. This pins down the
+// steady-state over-fire the medians showed (lazy-coarse renders ~+5% here).
+
+function makeStore() {
+  const auth = createSlice({
+    name: 'auth',
+    initialState: { role: 'user', loginCount: 0 },
+    reducers: { incrementLoginCount: (s) => void s.loginCount++ },
+  })
+  const preferences = createSlice({
+    name: 'preferences',
+    initialState: { updatedAt: 0 },
+    reducers: { touch: (s) => void (s.updatedAt = s.updatedAt + 1) },
+  })
+  const notifications = createSlice({
+    name: 'notifications',
+    initialState: { unreadCount: 0, totalCount: 0 },
+    reducers: {
+      incrementUnread: (s) => {
+        s.unreadCount++
+        s.totalCount++
+      },
+    },
+  })
+  const data = createSlice({
+    name: 'data',
+    initialState: {
+      items: { 0: { id: 0, value: 0 }, 1: { id: 1, value: 0 } } as Record<
+        number,
+        { id: number; value: number }
+      >,
+      lastUpdated: 0,
+    },
+    reducers: {
+      updateItem: (s, a: PayloadAction<number>) => {
+        s.items[a.payload].value++
+        s.lastUpdated++
+      },
+    },
+  })
+  const ui = createSlice({
+    name: 'ui',
+    initialState: { sidebarOpen: true, activeTab: 'dashboard', scrollPosition: 0 },
+    reducers: { updateScrollPosition: (s) => void (s.scrollPosition++) },
+  })
+
+  const store = configureStore({
+    reducer: combineReducers({
+      auth: auth.reducer,
+      preferences: preferences.reducer,
+      notifications: notifications.reducer,
+      data: data.reducer,
+      ui: ui.reducer,
+    }),
+  })
+  return {
+    store,
+    ...auth.actions,
+    ...preferences.actions,
+    ...notifications.actions,
+    ...data.actions,
+    ...ui.actions,
+  }
+}
+
+type RootState = ReturnType<ReturnType<typeof makeStore>['store']['getState']>
+
+let renders = 0
+const selRole = (s: RootState) => s.auth.role
+const selUnread = (s: RootState) => s.notifications.unreadCount
+const selItem = (s: RootState) => s.data.items[0]
+const selUi = (s: RootState) => ({
+  sidebar: s.ui.sidebarOpen,
+  tab: s.ui.activeTab,
+})
+
+function Card() {
+  renders++
+  useSignalSelector(selRole)
+  useSignalSelector(selUnread)
+  useSignalSelector(selItem)
+  useSignalSelector(selUi, shallowEqual)
+  return null
+}
+
+describe('multi-selector steady-state over-fire', () => {
+  it('actions that change a read segment but not the read field cause 0 re-renders after warmup', () => {
+    const s = makeStore()
+    rtl.render(
+      <SignalProvider store={s.store}>
+        <Card />
+      </SignalProvider>,
+    )
+
+    // Warm up: touch every segment once so all hooks build their deep graph.
+    rtl.act(() => {
+      s.store.dispatch(s.incrementLoginCount()) // auth
+      s.store.dispatch(s.touch()) // preferences
+      s.store.dispatch(s.incrementUnread()) // notifications
+      s.store.dispatch(s.updateItem(0)) // data
+      s.store.dispatch(s.updateScrollPosition()) // ui
+    })
+
+    const measure = (label: string, fn: () => void) => {
+      const before = renders
+      rtl.act(fn)
+      return { label, delta: renders - before }
+    }
+
+    const results = [
+      measure('loginCount (auth, not role)', () => {
+        s.store.dispatch(s.incrementLoginCount())
+      }),
+      measure('touch (preferences, unread)', () => {
+        s.store.dispatch(s.touch())
+      }),
+      measure('scrollPosition (ui, not sidebar/tab)', () => {
+        s.store.dispatch(s.updateScrollPosition())
+      }),
+      measure('updateItem(1) (data, other item)', () => {
+        s.store.dispatch(s.updateItem(1))
+      }),
+    ]
+
+    for (const r of results) {
+      expect(r.delta, r.label).toBe(0)
+    }
+  })
+})


### PR DESCRIPTION
Builds on #2354 (defer tracking off the mount render path) and takes it further. Adds a coarse top-level "segment" tier in front of the deep path tracking, so the per-selector proxy/signal graph is built **lazily** — only for hooks whose top-level slice actually changed — instead of eagerly for every hook at mount.

Net effect: the signals render/dispatch wins are kept, and the one remaining downside — modestly slower mount — goes away, with mount back at stock levels.

## How it works

- At mount a selector records only which top-level state keys it reads (one shallow proxy, cheap) — no deep graph is built.
- On dispatch the changed top-level segments are computed (reference compare, O(number of top-level keys)); only hooks reading a changed segment build their deep graph, on first touch. After that they're driven by the existing deep tracking exactly as before, so steady-state pruning is unchanged.
- The first-touch burst is time-sliced so it never blocks a frame (tunable via `sliceThreshold`).
- No tearing: an unbuilt hook's `getSnapshot` recomputes from the latest committed state, so it can't show a stale value against synchronously-updated siblings (test included).

## Scenario table (medians of 5 — stock → signals → this PR)

**Renders** (the "total work" metric):

| scenario | stock | signals | this PR |
| --- | --: | --: | --: |
| derived-selectors | 506 | 38 | 40 |
| price-ticker | 966 | 1106 | 1133 |
| entity-list / selective-update / deeptree | — | ≈ | ≈ |

**Dispatch avg (ms):**

| scenario | stock | signals | this PR |
| --- | --: | --: | --: |
| derived-selectors | 0.82 | 0.28 | 0.25 |
| entity-list-array | 0.95 | 0.45 | 0.42 |
| multi-selector-component | 0.83 | 0.47 | 0.34 |
| price-ticker | 5.96 | 2.48 | 2.48 |

**Mount (ms)** — the downside, now gone:

| scenario | stock | signals | this PR |
| --- | --: | --: | --: |
| derived-selectors | 5.9 | 29.0 | 6.2 |
| price-ticker | 27.8 | 158 | 29.5 |
| entity-list-array | 45 | 62 | 47 |

Renders and dispatch stay at signals levels; mount comes back to stock.

## At scale — price-ticker, 200k rows

| build | mount | dispatch avg |
| --- | --: | --: |
| stock 9.2 | 454 | 93.6 |
| signals (this PR's base) | 5905 | 12.9 |
| this PR | 553 | 23.9 |

Mount is ~10× better than signals; dispatch stays far under stock. Dispatch sits a bit above signals here only because signals front-loads all its work at mount (the ~5.9s) while this PR spreads it across the first seconds of updates — net it saves ~5.3s at load.

## Tradeoffs

- `sliceThreshold` (default 64): above it, a large first-touch burst is time-sliced (responsive, but those updates stagger during the burst); `Infinity` runs it inline (atomic, can block on a huge first touch). Steady-state updates are always synchronous, so this only affects the first touch of a slice.
- At extreme scale the warmup spreads the build work across the first seconds of dispatches; once warm, it equals signals.
