### PR TITLE
docs: fix two broken internal doc links

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ If you have context issues,
 
 1. [Make sure you don’t have a duplicate instance of React](https://medium.com/@dan_abramov/two-weird-tricks-that-fix-react-7cf9bbdef375) on the page.
 2. Make sure you don't have multiple instances/copies of React Redux in your project.
-3. Make sure you didn’t forget to wrap your root or some other ancestor component in [`<Provider>`](#provider-store).
+3. Make sure you didn’t forget to wrap your root or some other ancestor component in [`<Provider>`](./api/Provider.md).
 4. Make sure you’re running the latest versions of React and React Redux.
 
 ### Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. This usually means that you’re trying to add a ref to a component that doesn’t have an owner

--- a/docs/using-react-redux/accessing-store.md
+++ b/docs/using-react-redux/accessing-store.md
@@ -30,7 +30,7 @@ React Redux's `<Provider>` component uses `<ReactReduxContext.Provider>` to put 
 
 ## Using the `useStore` Hook
 
-The [`useStore` hook](../api/hooks.md#useStore) returns the current store instance from the default `ReactReduxContext`. If you truly need to access the store, this is the recommended approach.
+The [`useStore` hook](../api/hooks.md#usestore) returns the current store instance from the default `ReactReduxContext`. If you truly need to access the store, this is the recommended approach.
 
 ## Providing Custom Context
 


### PR DESCRIPTION
`docs/` has exactly two broken internal links, and both are fixed here.

- `troubleshooting.md` pointed `<Provider>` at `#provider-store`, an anchor that exists on no page. It now points at the Provider API page.
- `using-react-redux/accessing-store.md` pointed at `../api/hooks.md#useStore`, but `## useStore()` generates the lowercase id `usestore`, so the link landed at the top of the Hooks page. Reported back in 2020 in #1633. The other link on that page already uses the lowercase form.

Docs-only change.