### PR TITLE
Modern Tooling, Part 6: Vitest Typetest Syntax

### DIFF
--- a/src/utils/react-is.ts
+++ b/src/utils/react-is.ts
@@ -84,6 +84,8 @@ function typeOf(object: any): symbol | undefined {
         return $$typeof
     }
   }
+
+  return undefined
 }
 
 export function isContextConsumer(object: any): object is ReactElement {

--- a/test/typeTestHelpers.ts
+++ b/test/typeTestHelpers.ts
@@ -1,7 +1,0 @@
-export type IsEqual<A, B> =
-  (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2
-    ? true
-    : false
-
-export type IfEquals<T, U, TypeIfEquals = unknown, TypeIfNotEquals = never> =
-  IsEqual<T, U> extends true ? TypeIfEquals : TypeIfNotEquals

--- a/test/typetests/hooks.test-d.tsx
+++ b/test/typetests/hooks.test-d.tsx
@@ -62,15 +62,17 @@ describe('type tests', () => {
 
     expectTypeOf(notSimpleSelect).toBeCallableWith(state, ownProps)
 
-    expectTypeOf(simpleSelect).parameter(1).not.toMatchTypeOf(ownProps)
+    expectTypeOf(simpleSelect).parameter(1).not.toExtend<typeof ownProps>()
 
-    expectTypeOf(notSimpleSelect).parameters.not.toMatchTypeOf([state])
+    expectTypeOf(notSimpleSelect).parameters.not.toExtend<
+      [state: typeof state]
+    >()
   })
 
   test('shallowEqual', () => {
     expectTypeOf(shallowEqual).parameter(0).not.toBeNever()
 
-    expectTypeOf(shallowEqual).parameters.not.toMatchTypeOf<['a']>()
+    expectTypeOf(shallowEqual).parameters.not.toExtend<[objA: string]>()
 
     expectTypeOf(shallowEqual).toBeCallableWith('a', 'a')
 
@@ -120,9 +122,9 @@ describe('type tests', () => {
 
     expectTypeOf(dispatch)
       .parameter(0)
-      .not.toMatchTypeOf(thunkActionCreator(true))
+      .not.toExtend<ReturnType<typeof thunkActionCreator>>()
 
-    expectTypeOf(dispatch).parameter(0).not.toMatchTypeOf(true)
+    expectTypeOf(dispatch).parameter(0).not.toBeBoolean()
 
     const store = configureStore({
       reducer: (state = 0) => state,
@@ -163,8 +165,8 @@ describe('type tests', () => {
 
     expectTypeOf(useSelector(selector)).not.toHaveProperty('extraneous')
 
-    expectTypeOf(useSelector).parameters.not.toMatchTypeOf<
-      [typeof selector, 'a']
+    expectTypeOf(useSelector).parameters.not.toExtend<
+      [selector: typeof selector, equalityFnOrOptions: 'a']
     >()
 
     useSelector(selector, (l, r) => l === r)
@@ -230,7 +232,7 @@ describe('type tests', () => {
 
     const typedState = typedStore.getState()
 
-    expectTypeOf(typedState).toHaveProperty('counter')
+    expectTypeOf(typedState).toHaveProperty('counter').toBeNumber()
 
     expectTypeOf(typedState).not.toHaveProperty('things')
   })
@@ -251,25 +253,21 @@ describe('type tests', () => {
     > | null>(null)
 
     test('no context', () => {
-      expectTypeOf(createDispatchHook()).toMatchTypeOf<
-        () => Dispatch<AnyAction>
-      >()
+      expectTypeOf(createDispatchHook()).toExtend<() => Dispatch<AnyAction>>()
 
       expectTypeOf(createSelectorHook()).toEqualTypeOf<UseSelector>()
 
-      expectTypeOf(createStoreHook()).toMatchTypeOf<
-        () => Store<any, AnyAction>
-      >()
+      expectTypeOf(createStoreHook()).toExtend<() => Store<any, AnyAction>>()
     })
 
     test('with context', () => {
-      expectTypeOf(createDispatchHook(Context)).toMatchTypeOf<
+      expectTypeOf(createDispatchHook(Context)).toExtend<
         () => Dispatch<RootAction>
       >()
 
       expectTypeOf(createSelectorHook(Context)).toEqualTypeOf<UseSelector>()
 
-      expectTypeOf(createStoreHook(Context)).toMatchTypeOf<
+      expectTypeOf(createStoreHook(Context)).toExtend<
         () => Store<RootState, RootAction>
       >()
     })

--- a/test/typetests/hooks.withTypes.test-d.tsx
+++ b/test/typetests/hooks.withTypes.test-d.tsx
@@ -29,11 +29,11 @@ describe('type tests', () => {
 
       expectTypeOf(state.counter).toBeNumber()
 
-      // NOTE: We can't do `expectTypeOf(store.dispatch).toBeCallableWith(incrementAsync(1))`
-      // because `.toBeCallableWith()` does not work well with function overloads.
       store.dispatch(incrementAsync(1))
 
-      expectTypeOf(store.dispatch).toEqualTypeOf(dispatch)
+      expectTypeOf(store.dispatch).toBeCallableWith(incrementAsync(1))
+
+      expectTypeOf(store.dispatch).toEqualTypeOf<typeof dispatch>()
 
       return (
         <button

--- a/test/typetests/provider.test-d.tsx
+++ b/test/typetests/provider.test-d.tsx
@@ -5,9 +5,11 @@ declare const store: Store<{ foo: string }>
 
 describe('type tests', () => {
   test('Provider', () => {
-    expectTypeOf(Provider)
-      .parameter(0)
-      .not.toMatchTypeOf({ store, serverState: 'oops', children: 'foo' })
+    expectTypeOf(Provider).parameter(0).not.toExtend<{
+      store: typeof store
+      serverState: string
+      children: string
+    }>()
 
     const App = () => {
       return (

--- a/test/typetests/react-redux-types.test-d.tsx
+++ b/test/typetests/react-redux-types.test-d.tsx
@@ -256,7 +256,7 @@ let anElement: ReactElement<TestProp>
 class NonComponent {}
 
 // this doesn't compile
-expectTypeOf(connect()).parameter(0).not.toMatchTypeOf(NonComponent)
+expectTypeOf(connect()).parameter(0).not.toExtend<typeof NonComponent>()
 
 // stateless functions
 interface HelloMessageProps {
@@ -351,10 +351,9 @@ describe('type tests', () => {
       mapStateToPropsWithoutOwnProps,
     )(OwnPropsComponent)
 
-    expectTypeOf(React.createElement).parameters.not.toMatchTypeOf([
-      ConnectedWithoutOwnProps,
-      { anything: 'goes!' },
-    ] as const)
+    expectTypeOf(React.createElement).parameters.not.toExtend<
+      readonly [typeof ConnectedWithoutOwnProps, { anything: 'goes!' }]
+    >()
 
     // This compiles, as expected.
     /**


### PR DESCRIPTION
Ports the type-test hunks from #2325. expect-type deprecated
toMatchTypeOf in 1.2.0; all 13 call sites become toExtend, except
one that becomes toBeBoolean. Value-argument forms are rewritten as
explicit type arguments so the assertions read as type assertions.

Also re-enables a toBeCallableWith assertion that was commented out,
deletes the unused test/typeTestHelpers.ts, and adds an explicit
return undefined in react-is.ts (behavior-identical; emitted JS is
byte-identical).

Deliberately not taken from #2325: the override keyword hunks and
tsconfig strictness changes (noImplicitOverride belongs with the
strictness PR), and the src/hooks/useSelector.ts import specifier
change, which is not type-only and requires the use-sync-external-store
dependency bumps.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>