### PR TITLE
Modern Tooling, Part 7: TS7 partial support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,53 @@ jobs:
           pnpm exec tsc --version
           pnpm type-tests
 
+  test-types-typescript-7:
+    name: 'Test Types: TypeScript 7 (advisory)'
+
+    runs-on: ubuntu-latest
+    # Advisory only. TypeScript 7 is not a supported target yet, so this job
+    # reports differences without blocking the workflow.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['24.x']
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          # Every job here runs its own install step, with the flags that job
+          # needs. pnpm/setup installs by default, which would install twice.
+          install: false
+
+      - name: Use node ${{ matrix.node }}
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      # Installed under an npm alias so the `typescript` devDependency, and
+      # every other tool that resolves it, stays on the supported version.
+      - name: Install TypeScript 7
+        run: pnpm add -D typescript-7@npm:typescript@7
+
+      # Invoked by path rather than through `pnpm exec tsc`. The alias also
+      # claims the `tsc` bin, so `pnpm exec tsc` happens to resolve to 7 today,
+      # but relying on that would let this job silently test the wrong compiler.
+      - name: Test types with TypeScript 7
+        run: |
+          node node_modules/typescript-7/bin/tsc --version
+          node node_modules/typescript-7/bin/tsc -p tsconfig.test.json --noEmit
+
   are-the-types-wrong:
     name: Check package config with are-the-types-wrong
 

--- a/test/typetests/connect-mapstate-mapdispatch.test-d.tsx
+++ b/test/typetests/connect-mapstate-mapdispatch.test-d.tsx
@@ -389,6 +389,67 @@ describe('type tests', () => {
     const verify = <Test foo="bar" />
   })
 
+  test('map state factory with mergeProps and options', () => {
+    interface OwnProps {
+      foo: string
+    }
+    interface StateProps {
+      bar: number
+    }
+
+    class TestComponent extends React.Component<OwnProps & StateProps> {}
+
+    const mapStateToPropsFactory = () => () => ({
+      bar: 1,
+    })
+
+    const mapDispatchToProps = () => ({
+      onClick: () => {},
+    })
+
+    const mergeProps = (
+      stateProps: StateProps,
+      dispatchProps: unknown,
+      ownProps: OwnProps,
+    ) => ({ ...stateProps, ...ownProps })
+
+    // `stateProps` is deliberately not annotated here, so the type of the
+    // state props has to come from inferring the factory form.
+    const WithMergeProps = connect(
+      mapStateToPropsFactory,
+      null,
+      (stateProps, dispatchProps, ownProps: OwnProps) => ({
+        ...ownProps,
+        bar: stateProps.bar,
+      }),
+    )(TestComponent)
+    const verifyMergeProps = <WithMergeProps foo="bar" />
+
+    const WithOptions = connect(
+      mapStateToPropsFactory,
+      null,
+      null,
+      {},
+    )(TestComponent)
+    const verifyOptions = <WithOptions foo="bar" />
+
+    const WithDispatchAndOptions = connect(
+      mapStateToPropsFactory,
+      mapDispatchToProps,
+      null,
+      {},
+    )(TestComponent)
+    const verifyDispatchAndOptions = <WithDispatchAndOptions foo="bar" />
+
+    const WithEverything = connect(
+      mapStateToPropsFactory,
+      mapDispatchToProps,
+      mergeProps,
+      {},
+    )(TestComponent)
+    const verifyEverything = <WithEverything foo="bar" />
+  })
+
   test('map state and dispatch and merge', () => {
     interface OwnProps {
       foo: string


### PR DESCRIPTION
This PR adds an advisory-only TS7 job and expands the `connect` typetests

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>